### PR TITLE
Fixed bug for setting bin width

### DIFF
--- a/src/MuonDataLib/data/events/instrument.py
+++ b/src/MuonDataLib/data/events/instrument.py
@@ -21,7 +21,7 @@ class Instrument(object):
     Each Instrument represents a single run.
 
     Methods:
-    - set_bins: set the bins for the histograms.
+    - set_bin_width: set the bins for the histograms.
     - get_histograms: gets the histogram values and bin edges.
     - add_new_frame: adds a new frame to all of the detectors.
     - add_event_data: sorts and adds event data to each detector.
@@ -40,11 +40,11 @@ class Instrument(object):
         self._current_frame = -1
         self._current_index = None
         self._bounds = [0, 30]
-        self.set_bins(.5)
+        self.set_bin_width(.5)
         # ns to micro sec
         self._unit_conversion = 1.e-3
 
-    def set_bins(self, bin_width):
+    def set_bin_width(self, bin_width):
         """
         Sets bin edges to a constant width from 0 to 30 micro sec.
         :param bin_width: the bin width to use when calculating the

--- a/test/data/events/instrument_test.py
+++ b/test/data/events/instrument_test.py
@@ -190,7 +190,7 @@ class InstrumentTest(TestHelper):
         inst = Instrument(DATE, 2)
         # change the bounds to make test simpiler
         inst._bounds = [1, 4]
-        inst.set_bins(0.5)
+        inst.set_bin_width(0.5)
         self.assertArrays(inst._bin_edges,
                           [1., 1.5, 2, 2.5, 3, 3.5, 4])
 
@@ -205,7 +205,7 @@ class InstrumentTest(TestHelper):
                             [1.2, 4.1],
                             [0, 4])
         inst._bounds = [0, 10]
-        inst.set_bins(1.)
+        inst.set_bin_width(1.)
         # check detector 0
         y, x = inst.get_histogram(0)
         self.assertArrays(x, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/test/data/loader/load_event_test.py
+++ b/test/data/loader/load_event_test.py
@@ -112,6 +112,21 @@ class LoadEventDataTest(TestHelper):
         self.assertArrays(bins, np.arange(0, 30.5, .5))
         self.assertEqual(len(hist[0]), 64)
 
+    def test_set_bin_width(self):
+        file_full = os.path.join(os.path.dirname(__file__),
+                                 '..',
+                                 '..',
+                                 'data_files',
+                                 'simple_test.nxs')
+
+        full_data = LoadEventData()
+        full_data.load_data(file_full)
+        full_data.set_bin_width(0.1)
+
+        hist, bins = full_data.get_histograms()
+        self.assertArrays(bins, np.arange(0, 30.1, .1))
+        self.assertEqual(len(hist[0]), 64)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Please use a descriptive name for the PR.
It will be used for the automated release notes along with the labels.
The labels that are used are:
 - ignore-for-release-notes
 - Data Loader
 - Maintenance
 - New Feature
 - bug
-->

### Description of work

#### Summary of work
This fixes a bug where the wrong method was used when fixing the bin width. 

*There is no associated issue.*


### To test:

Something like this would work:
```
from MuonDataLib.plot.basic import Figure
from MuonDataLib.data.loader.load_event import LoadEventData
import os

# set up data to plot
file = os.path.join(os.path.dirname(__file__),
                    'test',
                    'data_files',
                    'complete_run.nxs')


file_0 = os.path.join(os.path.dirname(__file__),
                    'test',
                    'data_files',
                    'partial_run.nxs')

# create data loaders and get histograms
data_p = LoadEventData()
data_p.load_data(file_0)

# mock reload by manually changing file
data_p._file_name = file
data_p.reload_data()

data_p.set_bin_width(0.016)

# create plots
fig = Figure('compare part and full')
# these plot the 0, 1 and 2 detector ID's
fig.plot_from_instrument(data_p, [0,1,2], 'Reload')

fig.show()


```

#### Code Review

- Is the code of an acceptable quality?
- Are the unit tests small and test the class in isolation?
- Does the documentation build [ReadTheDocs](https://readthedocs.org/projects/muondatalib/builds/)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.

