### PR TITLE
Write event data to muon nexus file

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,12 +1,6 @@
 name: Build and upload to PyPI
 
 on:
-  push:
-    branches:
-    - 'main'
-  pull_request:
-    branches:
-      - 'main'
   pull_request_review:
     types: [submitted]
 permissions:
@@ -15,7 +9,7 @@ permissions:
 jobs:
   update_version:
     name: update version
-    #if: github.event.review.state == 'approved'
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,6 +1,12 @@
 name: Build and upload to PyPI
 
 on:
+  push:
+    branches:
+    - 'main'
+  pull_request:
+    branches:
+      - 'main'
   pull_request_review:
     types: [submitted]
 permissions:
@@ -9,7 +15,7 @@ permissions:
 jobs:
   update_version:
     name: update version
-    if: github.event.review.state == 'approved'
+    #if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
       - name: Update version on merge
         run:  |
             python tools/version.py "beta"
@@ -38,17 +38,16 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
       - uses: actions/download-artifact@v3
         with:
           name: pyproject
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.0
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           # List of platforms to build on (incl. Python version)
-          CIBW_BUILD: cp3{9,10,11}-manylinux_x86_64 cp3{9,10,11}-win_amd64 cp3{9,10,11}-macosx_arm64
-
+          CIBW_BUILD: cp3{8,9,10,11,12}-manylinux_x86_64 cp3{8,9,10,11,12}-macosx_x86_64 cp3{8,9,10,11,12}-macosx_arm64 cp3{8,9,10,11,12}-win_amd64
           CIBW_BEFORE_BUILD: >
              pip install numpy Cython
           # Install test dependencies and run tests
@@ -62,6 +61,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    needs: [update_version]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
@@ -105,7 +105,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
           repository: ${{github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,7 +3,10 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
-      - 'release-next'
+    - 'main'
+  pull_request:
+    branches:
+      - 'main'
 
 permissions:
   contents: write

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Update version on merge
         run:  |
             python tools/version.py "minor"
+            pipx run cibuildwheel --platform linux --print-build-identifiers statsmodels/
       - name: Store changes
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -1,7 +1,6 @@
 name: Build and upload release to PyPI
 
 on:
-on:
   push:
     branches:
       - 'release-next'

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -56,7 +56,7 @@ jobs:
         #   CIBW_SOME_OPTION: value
         env:
           # List of platforms to build on
-          CIBW_BUILD: cp3{11}-manylinux_x86_64 cp3{11}-macosx_x86_64 cp3{11}-macosx_arm64 cp3{11}-win_amd64
+          CIBW_BUILD: cp3{11,12}-manylinux_x86_64 cp3{11,12}-macosx_x86_64 cp3{11,12}-macosx_arm64 cp3{11,12}-win_amd64
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,10 +3,7 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
-    - 'main'
-  pull_request:
-    branches:
-      - 'main'
+    - 'release-next'
 
 permissions:
   contents: write

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -65,6 +65,7 @@ jobs:
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    needs: [update_version]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,13 +3,6 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
-    - 'main'
-  pull_request:
-    branches:
-      - 'main'
-
-  push:
-    branches:
       - 'release-next'
 
 permissions:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - 'main'
 
-  push:
-    branches:
-      - 'release-next'
-
 permissions:
   contents: write
 

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -37,28 +37,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+        python_version: ['3.11']
     needs: [update_version]
     steps:
       - name: checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
       - uses: actions/download-artifact@v3
         with:
           name: pyproject
-
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.1 numpy cython
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
-        env:
-          # List of platforms to build on (incl. Python version)
-          CIBW_BUILD: cp3{12}-manylinux_x86_64 cp3{12}-win_amd64 cp3{12}-macosx_arm64
-
-          CIBW_BEFORE_BUILD: >
-             pip install numpy Cython
-          # Install test dependencies and run tests
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: >
-            pytest {project}/test
+        run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,6 +3,13 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
+    - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+  push:
+    branches:
       - 'release-next'
 
 permissions:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ github.event.push.head.ref }} == 'release-next'
         uses: actions/checkout@v4
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
           repository: ${{github.event.push.head.repo.full_name }}
           ref: ${{ github.event.push.head.ref }}
 

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -22,8 +22,9 @@ jobs:
           fetch-depth: "0"
       - name: Update version on merge
         run:  |
-            python tools/version.py "minor"
+            ls
             pipx run cibuildwheel --platform linux --print-build-identifiers statsmodels/
+            python tools/version.py "minor"
       - name: Store changes
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -19,7 +19,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: "0"
+          fetch-depth: "1"
       - name: Update version on merge
         run:  |
             python tools/version.py "minor"
@@ -51,7 +51,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.21.1
         env:
           # List of platforms to build on (incl. Python version)
-          CIBW_BUILD: cp3{11}-manylinux_x86_64 cp3{11}-win_amd64 cp3{11}-macosx_arm64
+          CIBW_BUILD: cp3{12}-manylinux_x86_64 cp3{12}-win_amd64 cp3{12}-macosx_arm64
 
           CIBW_BEFORE_BUILD: >
              pip install numpy Cython

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,6 +3,13 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
+    - 'main'
+  pull_request:
+    branches:
+      - 'main'
+
+  push:
+    branches:
       - 'release-next'
 
 permissions:
@@ -48,7 +55,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.8.0
         env:
           # List of platforms to build on (incl. Python version)
-          CIBW_BUILD: cp3{9,10,11}-manylinux_x86_64 cp3{9,10,11}-win_amd64 cp3{9,10,11}-macosx_arm64
+          CIBW_BUILD: cp3{11}-manylinux_x86_64 cp3{11}-win_amd64 cp3{11}-macosx_arm64
 
           CIBW_BEFORE_BUILD: >
              pip install numpy Cython

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -1,12 +1,10 @@
 name: Build and upload release to PyPI
 
 on:
+on:
   push:
     branches:
-    - 'main'
-  pull_request:
-    branches:
-      - 'main'
+      - 'release-next'
 
 permissions:
   contents: write

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -47,10 +47,16 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: pyproject
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.21.1 numpy cython
+      - name: Install
+        run: python -m pip install numpy cython
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.16.5
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+        env:
+          # List of platforms to build on
+          CIBW_BUILD: cp3{11}-manylinux_x86_64 cp3{11}-macosx_x86_64 cp3{11}-macosx_arm64 cp3{11}-win_amd64
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -3,10 +3,7 @@ name: Build and upload release to PyPI
 on:
   push:
     branches:
-    - 'main'
-  pull_request:
-    branches:
-      - 'main'
+      - 'release-next'
 
 permissions:
   contents: write
@@ -37,7 +34,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python_version: ['3.11']
     needs: [update_version]
     steps:
       - name: checkout
@@ -47,16 +43,18 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: pyproject
-      - name: Install
-        run: python -m pip install numpy cython
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
-        # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
         env:
           # List of platforms to build on
-          CIBW_BUILD: cp3{11,12}-manylinux_x86_64 cp3{11,12}-macosx_x86_64 cp3{11,12}-macosx_arm64 cp3{11,12}-win_amd64
+          CIBW_BUILD: cp3{8,9,10,11,12}-manylinux_x86_64 cp3{8,9,10,11,12}-macosx_x86_64 cp3{8,9,10,11,12}-macosx_arm64 cp3{8,9,10,11,12}-win_amd64
+          CIBW_BEFORE_BUILD: >
+             pip install numpy Cython
+          # Install test dependencies and run tests
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: >
+            pytest {project}/test
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release_next.yml
+++ b/.github/workflows/release_next.yml
@@ -22,8 +22,6 @@ jobs:
           fetch-depth: "0"
       - name: Update version on merge
         run:  |
-            ls
-            pipx run cibuildwheel --platform linux --print-build-identifiers statsmodels/
             python tools/version.py "minor"
       - name: Store changes
         uses: actions/upload-artifact@v3
@@ -50,7 +48,7 @@ jobs:
           name: pyproject
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.8.0
+        uses: pypa/cibuildwheel@v2.21.1
         env:
           # List of platforms to build on (incl. Python version)
           CIBW_BUILD: cp3{11}-manylinux_x86_64 cp3{11}-win_amd64 cp3{11}-macosx_arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ where = ["src"]
 
 [project]
 name = 'MuonDataLib'
-version = "0.6.0b4"
+version = "0.7.0b0"
 requires-python = ">=3.7.1"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython']
 authors = [{name='Anthony Lim', email='anthony.lim@stfc.ac.uk'}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ where = ["src"]
 
 [project]
 name = 'MuonDataLib'
-version = "0.9.0b0"
+version = "0.9.0b1"
 requires-python = ">=3.7.1"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython']
 authors = [{name='Anthony Lim', email='anthony.lim@stfc.ac.uk'}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ where = ["src"]
 
 [project]
 name = 'MuonDataLib'
-version = "0.6.0b3"
+version = "0.6.0b4"
 requires-python = ">=3.7.1"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython']
 authors = [{name='Anthony Lim', email='anthony.lim@stfc.ac.uk'}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ where = ["src"]
 
 [project]
 name = 'MuonDataLib'
-version = "0.7.0b0"
+version = "0.8.0b0"
 requires-python = ">=3.7.1"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython']
 authors = [{name='Anthony Lim', email='anthony.lim@stfc.ac.uk'}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ where = ["src"]
 
 [project]
 name = 'MuonDataLib'
-version = "0.8.0b0"
+version = "0.9.0b0"
 requires-python = ">=3.7.1"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython']
 authors = [{name='Anthony Lim', email='anthony.lim@stfc.ac.uk'}]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.6.0b4"
+version = "0.7.0b0"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.7.0b0"
+version = "0.8.0b0"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.6.0b3"
+version = "0.6.0b4"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.9.0b0"
+version = "0.9.0b1"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.8.0b0"
+version = "0.9.0b0"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ extensions = [
                 sources=["src/MuonDataLib/cython_ext/event_data.pyx"],
                 ),
               Extension(
+                "MuonDataLib.cython_ext.events_cache",
+                sources=["src/MuonDataLib/cython_ext/events_cache.pyx"],
+                ),
+              Extension(
                 "MuonDataLib.cython_ext.load_events",
                 sources=["src/MuonDataLib/cython_ext/load_events.pyx"],
                 ),

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -60,7 +60,8 @@ cdef class Events:
                                     max_time,
                                     width)
         if cache is not None:
-            cache.save(np.asarray([hist]), bins, len(self.start_index_list))
+            cache.save(np.asarray([hist]), bins,
+                       np.asarray([len(self.start_index_list)], dtype=np.int32))
         return hist, bins
 
     @property

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -15,19 +15,19 @@ cdef class Events:
     cdef readonly int N_spec
     cdef readonly cnp.int32_t[:] start_index_list
     cdef readonly cnp.int32_t[:] end_index_list
-    #cdef readonly cnp.ndarray[int] frame_start_time
 
     def __init__(self,
                  cnp.ndarray[int] IDs,
                  cnp.ndarray[double] times,
                  cnp.ndarray[int] start_i,
-                 int N_det): #, frame_time):
+                 int N_det):
         """
         Creates an event object.
         This knows everything needed for the events to create a histogram.
         :param IDs: the detector ID's for the events
         :param times: the time stamps for the events, relative to the start of their frame
         :param start_i: the first event index for each frame
+        :param N_det: the number of detectors
         """
         self.IDs = IDs
         self.N_spec = N_det
@@ -47,7 +47,11 @@ cdef class Events:
                   cache=None):
         """
         Create a matrix of histograms from the event data
-        ;returns: a matrix of histograms, bin edges
+        :param min_time: the start time for the histogram
+        :param max_time: the end time for the histogram
+        :param width: the bin width for the histogram
+        :param cache: the cache of event data histograms
+        :returns: a matrix of histograms, bin edges
         """
         hist, bins = make_histogram(self.times,
                                     self.IDs,

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -20,7 +20,8 @@ cdef class Events:
     def __init__(self,
                  cnp.ndarray[int] IDs,
                  cnp.ndarray[double] times,
-                 cnp.ndarray[int] start_i): #, frame_time):
+                 cnp.ndarray[int] start_i,
+                 int N_det): #, frame_time):
         """
         Creates an event object.
         This knows everything needed for the events to create a histogram.
@@ -29,19 +30,26 @@ cdef class Events:
         :param start_i: the first event index for each frame
         """
         self.IDs = IDs
-        # add as IDs counts from 0
-        self.N_spec = np.max(IDs) + 1
+        self.N_spec = N_det
         self.times = times
         self.start_index_list = start_i
         self.end_index_list = np.append(start_i[1:], np.int32(len(IDs)))
         #self.frame_start_time = frame_time
 
-    def histogram(self):
+    @property
+    def get_total_frames(self):
+        return len(self.start_index_list)
+
+    def histogram(self,
+                  min_time=0.,
+                  max_time=32.768,
+                  width=0.016):
         """
         Create a matrix of histograms from the event data
         ;returns: a matrix of histograms, bin edges
         """
-        return make_histogram(self.times, self.IDs, self.N_spec)
+        return make_histogram(self.times, self.IDs, self.N_spec,
+                              min_time, max_time, width)
 
     @property
     def get_N_spec(self):

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -41,15 +41,23 @@ cdef class Events:
         return len(self.start_index_list)
 
     def histogram(self,
-                  min_time=0.,
-                  max_time=32.768,
-                  width=0.016):
+                  double min_time=0.,
+                  double max_time=32.768,
+                  double width=0.016,
+                  cache=None):
         """
         Create a matrix of histograms from the event data
         ;returns: a matrix of histograms, bin edges
         """
-        return make_histogram(self.times, self.IDs, self.N_spec,
-                              min_time, max_time, width)
+        hist, bins = make_histogram(self.times,
+                                    self.IDs,
+                                    self.N_spec,
+                                    min_time,
+                                    max_time,
+                                    width)
+        if cache is not None:
+            cache.save(np.asarray([hist]), bins, len(self.start_index_list))
+        return hist, bins
 
     @property
     def get_N_spec(self):
@@ -65,13 +73,3 @@ cdef class Events:
         """
         return len(self.IDs)
 
-    @property
-    def get_filtered_events(self):
-        """
-        Later this will apply filters.
-        Either by adding subsets of the events, so to exclude the
-        filteref out frames.
-        Or by adding an offset to unwanted events (e.g. bad amplitudes)
-        :return: the IDs for the events
-        """
-        return self.IDs

--- a/src/MuonDataLib/cython_ext/events_cache.pyx
+++ b/src/MuonDataLib/cython_ext/events_cache.pyx
@@ -11,6 +11,7 @@ cdef class EventsCache:
     cdef readonly int[:, :, :] histograms
     cdef readonly double[:] bins
     cdef readonly int N_frames
+    cdef readonly int N_good_frames
 
     def __init__(self):
         """
@@ -25,6 +26,7 @@ cdef class EventsCache:
         self.histograms = None
         self.bins = None
         self.N_frames = 0
+        self.N_good_frames = 0
 
     def save(self,
             int[:, :, :] histograms,
@@ -39,6 +41,7 @@ cdef class EventsCache:
         self.histograms = histograms
         self.bins = bins
         self.N_frames = N_frames
+        self.N_good_frames = N_frames
 
     def get_histograms(self):
         """
@@ -55,6 +58,24 @@ cdef class EventsCache:
         if self.empty():
             raise RuntimeError("The cache is empty, cannot get frames")
         return self.N_frames
+
+    def set_good_frames(self, N):
+        """
+        :param N: the number of good frames
+        """
+        if N > self.N_good_frames:
+            raise RuntimeError(f"The number of good frames {N} "
+                               "cannot be larger than the number "
+                               "of frames {self.N_frames}")
+        self.N_good_frames = N
+
+    def get_good_frames(self):
+        """
+        :return: the number of good frames
+        """
+        if self.empty():
+            raise RuntimeError("The cache is empty, cannot get frames")
+        return self.N_good_frames
 
     def empty(self):
         """

--- a/src/MuonDataLib/cython_ext/events_cache.pyx
+++ b/src/MuonDataLib/cython_ext/events_cache.pyx
@@ -1,0 +1,43 @@
+import numpy as np
+cimport numpy as cnp
+import cython
+cnp.import_array()
+
+
+cdef class EventsCache:
+    cdef readonly int[:, :, :] histograms
+    cdef readonly double[:] bins
+    cdef readonly int N_frames
+
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        self.histograms = None
+        self.bins = None
+        self.N_frames = 0
+
+    def save(self,
+            int[:, :, :] histograms,
+            double[:] bins,
+            int N_frames):
+        self.histograms = histograms
+        self.bins = bins
+        self.N_frames = N_frames
+
+    def get_histograms(self):
+        return np.asarray(self.histograms), np.asarray(self.bins)
+
+    def get_total_frames(self):
+        return self.N_frames
+
+    def empty(self):
+        if self.N_frames==0:
+            return True
+        return False
+
+    def print(self):
+        print(np.asarray(self.histograms))
+        print(np.asarray(self.bins))
+        print(self.N_frames)
+

--- a/src/MuonDataLib/cython_ext/events_cache.pyx
+++ b/src/MuonDataLib/cython_ext/events_cache.pyx
@@ -5,14 +5,23 @@ cnp.import_array()
 
 
 cdef class EventsCache:
+    """
+    A simple class for caching the event data into histograms
+    """
     cdef readonly int[:, :, :] histograms
     cdef readonly double[:] bins
     cdef readonly int N_frames
 
     def __init__(self):
+        """
+        Create an empty cache
+        """
         self.clear()
 
     def clear(self):
+        """
+        Clear all data from the cache
+        """
         self.histograms = None
         self.bins = None
         self.N_frames = 0
@@ -21,23 +30,37 @@ cdef class EventsCache:
             int[:, :, :] histograms,
             double[:] bins,
             int N_frames):
+        """
+        Store data in the cache
+        :param histograms: the histogram data (periods, N_det, bin)
+        :param bins: the histogram bins
+        :param N_frames: the number of frames used
+        """
         self.histograms = histograms
         self.bins = bins
         self.N_frames = N_frames
 
     def get_histograms(self):
+        """
+        :return: the stored histograms and bins
+        """
+        if self.empty():
+            raise RuntimeError("The cache is empty, cannot get histograms")
         return np.asarray(self.histograms), np.asarray(self.bins)
 
     def get_total_frames(self):
+        """
+        :return: the total number of frames
+        """
+        if self.empty():
+            raise RuntimeError("The cache is empty, cannot get frames")
         return self.N_frames
 
     def empty(self):
+        """
+        Check if the cache is empty
+        :return: if the cache is empty as a bool
+        """
         if self.N_frames==0:
             return True
         return False
-
-    def print(self):
-        print(np.asarray(self.histograms))
-        print(np.asarray(self.bins))
-        print(self.N_frames)
-

--- a/src/MuonDataLib/cython_ext/load_events.pyx
+++ b/src/MuonDataLib/cython_ext/load_events.pyx
@@ -43,6 +43,7 @@ def load_data(file_name, N_det):
         """
         Loads the data from an event nxs file
         :param file_name: the name of the event nxs file to load
+        :param N_det: the number of detectors
         :return: the time to run this method, the total number of events
         """
         start = time.time()

--- a/src/MuonDataLib/cython_ext/load_events.pyx
+++ b/src/MuonDataLib/cython_ext/load_events.pyx
@@ -39,7 +39,7 @@ def _load_data(file_name):
 
         return IDs, start_j, times, amps, start_t
 
-def load_data(file_name):
+def load_data(file_name, N_det):
         """
         Loads the data from an event nxs file
         :param file_name: the name of the event nxs file to load
@@ -47,7 +47,7 @@ def load_data(file_name):
         """
         start = time.time()
         IDs, frames, times, amps, frame_times = _load_data(file_name)
-        events = Events(IDs, times, frames)
+        events = Events(IDs, times, frames, N_det)
         return time.time() - start, events
 
 

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -32,14 +32,14 @@ cpdef make_histogram(
 
     cdef cnp.ndarray[double, ndim=1] bins = np.arange(min_time, max_time + width, width, dtype=np.double)
 
-    cdef cnp.ndarray[double, ndim=2] result = np.zeros((N_spec, len(bins)-1), dtype=np.double)
-    cdef double[:, :] mat = result
+    cdef cnp.ndarray[int, ndim=2] result = np.zeros((N_spec, len(bins)-1), dtype=int)
+    cdef int[:, :] mat = result
 
     for k in range(len(times)):
         det = spec[k]
         time = times[k] * conversion
         if time <= max_time and time >= min_time:
             j_bin = int((time - min_time) // width)
-            mat[det, j_bin] += 1. / width
+            mat[det, j_bin] += 1 #/ width
     return result, bins
 

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -17,6 +17,10 @@ cpdef make_histogram(
     """
     This method creates histograms from a list of data.
     It produces a matrix of histograms for multiple spectra.
+    Strictly speaking these are not histograms as they
+    are not normalised to bin width.
+    This is the language used by the users and the
+    analysis code applys the normalisation.
     :param times: the times for the data
     :param spec: the spectra for the corresponding time
     :param N_spec: the number of spectra
@@ -40,6 +44,6 @@ cpdef make_histogram(
         time = times[k] * conversion
         if time <= max_time and time >= min_time:
             j_bin = int((time - min_time) // width)
-            mat[det, j_bin] += 1 #/ width
+            mat[det, j_bin] += 1
     return result, bins
 

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -36,7 +36,7 @@ cpdef make_histogram(
 
     cdef cnp.ndarray[double, ndim=1] bins = np.arange(min_time, max_time + width, width, dtype=np.double)
 
-    cdef cnp.ndarray[int, ndim=2] result = np.zeros((N_spec, len(bins)-1), dtype=int)
+    cdef cnp.ndarray[int, ndim=2] result = np.zeros((N_spec, len(bins)-1), dtype=np.int32)
     cdef int[:, :] mat = result
 
     for k in range(len(times)):

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -26,6 +26,7 @@ def load_events(file_name, N):
         start_time = convert_date(tmp['start_time'][()].decode().split('+')[0])
         end_time = convert_date(tmp['end_time'][()].decode().split('+')[0])
 
+    print(start_time, end_time, run_number)
     cache = EventsCache()
     _, events = load_data(file_name, N)
 
@@ -67,7 +68,7 @@ def load_events(file_name, N):
 
     detector1 = Det1(cache,
                      0.016,
-                     np.arange(1, N + 1),
+                     np.arange(1, N + 1, dtype=np.int32),
                      'HIFI test',
                      3,
                      9*0.016,

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -1,0 +1,110 @@
+from MuonDataLib.data.sample import Sample
+from MuonDataLib.data.raw_data import RawData
+from MuonDataLib.data.source import Source
+from MuonDataLib.data.user import User
+from MuonDataLib.data.periods import Periods
+from MuonDataLib.data.detector1 import Detector_1 as Detector1
+from MuonDataLib.data.muon_data import MuonData
+from MuonDataLib.cython_ext.load_events import load_data
+from MuonDataLib.data.utils import convert_date
+
+import h5py
+import numpy as np
+
+
+class Data(object):
+    def __init__(self, num, start, end):
+        self.events = None
+
+        self.run_number = int(num)
+        self.start = start
+        self.end = end
+
+    def add_events(self, file_name):
+        _, self.events = load_data(file_name, 64)
+
+    @property
+    def raw_frames(self):
+        return self.events.get_total_frames
+
+    def get_histogram(self):
+        return self.events.histogram()
+
+
+def load_events(file_name):
+    with h5py.File(file_name, 'r') as file:
+        tmp = file.require_group('raw_data_1')
+        num = tmp['run_number'][()]
+        start = convert_date(tmp['start_time'][()].decode().split('+')[0])
+        end = convert_date(tmp['end_time'][()].decode().split('+')[0])
+
+        data = Data(num, start, end)
+    data.add_events(file_name)
+    return data
+
+
+def save_events(data):
+
+    run_number = data.run_number
+    raw_frames = data.raw_frames
+    start_time = data.start
+    end_time = data.end
+    duration = (end_time - start_time).total_seconds()
+    good_frames = data.raw_frames
+    requested = data.raw_frames
+    # toal_counts appears to be zero in current files
+    total_counts = 0.0
+    counts, raw_time = data.get_histogram()
+
+    raw_data = RawData(good_frames,
+                       2,
+                       'pulsedTD',
+                       'HIFI',
+                       'Title: test',
+                       'Notes: test',
+                       run_number,
+                       duration,
+                       raw_frames,
+                       start_time,
+                       end_time,
+                       'raw ID: test')
+
+    sample = Sample('sample ID: test',
+                    1.1,
+                    2.2,
+                    3.3,
+                    4.4,
+                    5.5,
+                    'sample name: test')
+
+    source = Source('ISIS',
+                    'Probe',
+                    'Pulsed')
+
+    user = User('user name: RAL',
+                'affiliation: test')
+
+    periods = Periods(1,
+                      'label test',
+                      [1],
+                      [requested],
+                      [raw_frames],
+                      [0],
+                      [total_counts],
+                      [1])
+
+    detector1 = Detector1(0.016,
+                          raw_time,
+                          np.arange(1, 65),
+                          [counts],
+                          'HIFI test',
+                          3,
+                          9*0.016,
+                          2018*0.016)
+
+    return MuonData(sample=sample,
+                    raw_data=raw_data,
+                    source=source,
+                    user=user,
+                    periods=periods,
+                    detector1=detector1)

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -14,6 +14,12 @@ import numpy as np
 
 
 def load_events(file_name, N):
+    """
+    Load muon event nxs file (ISIS)
+    :param file_name: the name of the file to load
+    :param N: the number of detectors
+    :return: a MuonEventData object
+    """
     with h5py.File(file_name, 'r') as file:
         tmp = file.require_group('raw_data_1')
         run_number = int(tmp['run_number'][()])

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -1,73 +1,41 @@
 from MuonDataLib.data.sample import Sample
-from MuonDataLib.data.raw_data import RawData
+from MuonDataLib.data.raw_data import EventsRawData
 from MuonDataLib.data.source import Source
 from MuonDataLib.data.user import User
-from MuonDataLib.data.periods import Periods
-from MuonDataLib.data.detector1 import Detector_1 as Detector1
-from MuonDataLib.data.muon_data import MuonData
+from MuonDataLib.data.periods import EventsPeriods
+from MuonDataLib.data.detector1 import EventsDetector_1 as Det1
+from MuonDataLib.data.muon_data import MuonEventData
 from MuonDataLib.cython_ext.load_events import load_data
+from MuonDataLib.cython_ext.events_cache import EventsCache
 from MuonDataLib.data.utils import convert_date
 
 import h5py
 import numpy as np
 
 
-class Data(object):
-    def __init__(self, num, start, end):
-        self.events = None
-
-        self.run_number = int(num)
-        self.start = start
-        self.end = end
-
-    def add_events(self, file_name):
-        _, self.events = load_data(file_name, 64)
-
-    @property
-    def raw_frames(self):
-        return self.events.get_total_frames
-
-    def get_histogram(self):
-        return self.events.histogram()
-
-
-def load_events(file_name):
+def load_events(file_name, N):
     with h5py.File(file_name, 'r') as file:
         tmp = file.require_group('raw_data_1')
-        num = tmp['run_number'][()]
-        start = convert_date(tmp['start_time'][()].decode().split('+')[0])
-        end = convert_date(tmp['end_time'][()].decode().split('+')[0])
+        run_number = int(tmp['run_number'][()])
+        start_time = convert_date(tmp['start_time'][()].decode().split('+')[0])
+        end_time = convert_date(tmp['end_time'][()].decode().split('+')[0])
 
-        data = Data(num, start, end)
-    data.add_events(file_name)
-    return data
+    cache = EventsCache()
+    _, events = load_data(file_name, N)
 
-
-def save_events(data):
-
-    run_number = data.run_number
-    raw_frames = data.raw_frames
-    start_time = data.start
-    end_time = data.end
     duration = (end_time - start_time).total_seconds()
-    good_frames = data.raw_frames
-    requested = data.raw_frames
-    # toal_counts appears to be zero in current files
-    total_counts = 0.0
-    counts, raw_time = data.get_histogram()
 
-    raw_data = RawData(good_frames,
-                       2,
-                       'pulsedTD',
-                       'HIFI',
-                       'Title: test',
-                       'Notes: test',
-                       run_number,
-                       duration,
-                       raw_frames,
-                       start_time,
-                       end_time,
-                       'raw ID: test')
+    raw_data = EventsRawData(cache,
+                             2,
+                             'pulsedTD',
+                             'HIFI',
+                             'Title: test',
+                             'Notes: test',
+                             run_number,
+                             duration,
+                             start_time,
+                             end_time,
+                             'raw ID: test')
 
     sample = Sample('sample ID: test',
                     1.1,
@@ -84,27 +52,26 @@ def save_events(data):
     user = User('user name: RAL',
                 'affiliation: test')
 
-    periods = Periods(1,
-                      'label test',
-                      [1],
-                      [requested],
-                      [raw_frames],
-                      [0],
-                      [total_counts],
-                      [1])
+    periods = EventsPeriods(cache,
+                            1,
+                            'label test',
+                            [1],
+                            [0],
+                            [1])
 
-    detector1 = Detector1(0.016,
-                          raw_time,
-                          np.arange(1, 65),
-                          [counts],
-                          'HIFI test',
-                          3,
-                          9*0.016,
-                          2018*0.016)
+    detector1 = Det1(cache,
+                     0.016,
+                     np.arange(1, N + 1),
+                     'HIFI test',
+                     3,
+                     9*0.016,
+                     2018*0.016)
 
-    return MuonData(sample=sample,
-                    raw_data=raw_data,
-                    source=source,
-                    user=user,
-                    periods=periods,
-                    detector1=detector1)
+    return MuonEventData(events,
+                         cache,
+                         sample=sample,
+                         raw_data=raw_data,
+                         source=source,
+                         user=user,
+                         periods=periods,
+                         detector1=detector1)

--- a/src/MuonDataLib/data/muon_data.py
+++ b/src/MuonDataLib/data/muon_data.py
@@ -34,3 +34,32 @@ class MuonData(object):
             self._dict[key].save_nxs2(file)
         file.close()
         return
+
+
+class MuonEventData(MuonData):
+    def __init__(self, events, cache, sample, raw_data, source, user,
+                 periods, detector1):
+        """
+        Creates a store for relevant muon data (defined by nxs v2)
+        :param events: the event data
+        :param cache: the cache for the event data
+        :param sample: the Sample data needed for nexus v2 file
+        :param raw_data: the RawData data needed for nexus v2 file
+        :param source: the Source data needed for nexus v2 file
+        :param user: the User data needed for nexus v2 file
+        :param periods: the Periods data needed for nexus v2 file
+        :param detector1: the Detector1 data needed for nexus v2 file
+        """
+        self._events = events
+        self._cache = cache
+        super().__init__(sample, raw_data, source, user, periods, detector1)
+
+    def save_histograms(self, file_name):
+        """
+        Method for saving the object to a muon
+        nexus v2 histogram file
+        :param file_name: the name of the file to save to
+        """
+        if self._cache.empty():
+            self._events.histogram(cache=self._cache)
+        super().save_histograms(file_name)

--- a/src/MuonDataLib/data/periods.py
+++ b/src/MuonDataLib/data/periods.py
@@ -43,7 +43,7 @@ class _Periods(HDF5):
         self.save_int_array('frames_requested', requested, tmp)
         self.save_int_array('raw_frames', raw, tmp)
         self.save_int_array('output', self._dict['output'], tmp)
-        self.save_int_array('total_counts', counts, tmp)
+        self.save_float_array('total_counts', counts, tmp)
 
 
 class Periods(_Periods):
@@ -66,7 +66,7 @@ class Periods(_Periods):
         super().__init__(number, labels, p_type, output, sequences)
         self._dict['requested'] = requested
         self._dict['raw'] = raw
-        self._dict['counts'] = counts
+        self._dict['total_counts'] = counts
 
     def save_nxs2(self, file):
         """
@@ -77,7 +77,7 @@ class Periods(_Periods):
         super().save_nxs2(file,
                           self._dict['requested'],
                           self._dict['raw'],
-                          self._dict['counts'])
+                          self._dict['total_counts'])
 
 
 class EventsPeriods(_Periods):
@@ -106,11 +106,12 @@ class EventsPeriods(_Periods):
         """
         # in the examples the counts always seems to be zero
         # but will set it to be the sum for the period
-        counts = []
+
         hist, _ = self._cache.get_histograms()
+        counts = np.zeros(self._dict['number'], dtype=np.double)
         for k in range(self._dict['number']):
-            counts.append(np.sum(hist[k]))
-        counts = np.asarray(counts, dtype=np.int32)
+            # store MeV
+            counts[k] = float(np.sum(hist[k]))/1.e6
 
         super().save_nxs2(file,
                           np.asarray(self._cache.get_requested_frames()),

--- a/src/MuonDataLib/data/periods.py
+++ b/src/MuonDataLib/data/periods.py
@@ -43,7 +43,7 @@ class _Periods(HDF5):
         self.save_int_array('frames_requested', requested, tmp)
         self.save_int_array('raw_frames', raw, tmp)
         self.save_int_array('output', self._dict['output'], tmp)
-        self.save_float_array('total_counts', counts, tmp)
+        self.save_int_array('total_counts', counts, tmp)
 
 
 class Periods(_Periods):
@@ -104,12 +104,18 @@ class EventsPeriods(_Periods):
         nexus v2 file
         :param file: the open file to write to
         """
-        N = np.asarray([self._cache.get_total_frames()], dtype=int)
         # in the examples the counts always seems to be zero
+        # but will set it to be the sum for the period
+        counts = []
+        hist, _ = self._cache.get_histograms()
+        for k in range(self._dict['number']):
+            counts.append(np.sum(hist[k]))
+        counts = np.asarray(counts, dtype=np.int32)
+
         super().save_nxs2(file,
-                          N,
-                          N,
-                          np.asarray([0], dtype=np.double))
+                          np.asarray(self._cache.get_requested_frames()),
+                          np.asarray(self._cache.get_total_frames()),
+                          counts)
 
 
 def read_periods_from_histogram(file):

--- a/src/MuonDataLib/data/raw_data.py
+++ b/src/MuonDataLib/data/raw_data.py
@@ -4,7 +4,69 @@ from MuonDataLib.data.utils import (convert_date_for_NXS,
 from MuonDataLib.data.hdf5 import HDF5
 
 
-class RawData(HDF5):
+class _RawData(HDF5):
+    """
+    A base class for storing the "raw data" information for a
+    muon nexus v2 file
+    """
+    def __init__(self, IDF, definition, inst, title, notes,
+                 run_number, duration, start_time, end_time, ID):
+        """
+        Creates the raw data object, which holds all of the information
+        for the raw data section of a muon nexus v2 file
+        :param IDF: the version of the Instrument Definition File (IDF)
+        :param definition: the definition (e.g. pulsedTD)
+        :param inst: the instrument name
+        :param title: the title of the experiment
+        :param notes: the additional notes/comments
+        :param run_number: the run number
+        :param duration: the duration of the experiment
+        :param start_time: the start time of the experiment
+        :param end_time: the end time of the experiment
+        :param ID: a string identifier for the experiment
+        """
+        super().__init__()
+        self._dict['IDF'] = IDF
+        self._dict['def'] = definition
+        self._dict['inst'] = inst
+        self._dict['title'] = title
+        self._dict['notes'] = notes
+        self._dict['run_number'] = run_number
+        self._dict['duration'] = duration
+        self._dict['start'] = start_time
+        self._dict['end'] = end_time
+        self._dict['ID'] = ID
+
+    def save_nxs2(self, file, good_frames, raw_frames):
+        """
+        A method to save the information into a muon nexus v2 file
+        :param file: the open file to write to.
+        :param good_frames: the number of good frames
+        :param raw_frames: the number of raw frames
+        """
+        tmp = file.require_group('raw_data_1')
+        tmp.attrs['NX_class'] = 'NXentry'
+
+        self.save_int('good_frames', good_frames, tmp)
+        self.save_int('IDF_version', self._dict['IDF'], tmp)
+        self.save_str('definition', self._dict['def'], tmp)
+        self.save_str('name', self._dict['inst'], tmp)
+        self.save_str('title', self._dict['title'], tmp)
+        self.save_str('notes', self._dict['notes'], tmp)
+        self.save_int('run_number', self._dict['run_number'], tmp)
+        self.save_float('duration', self._dict['duration'], tmp)
+        self.save_int('raw_frames', raw_frames, tmp)
+        self.save_str('start_time',
+                      convert_date_for_NXS(self._dict['start']),
+                      tmp)
+        self.save_str('end_time', convert_date_for_NXS(self._dict['end']), tmp)
+        self.save_str('experiment_identifier', self._dict['ID'], tmp)
+
+        tmp = tmp.require_group('instrument')
+        self.save_str('name', self._dict['inst'], tmp)
+
+
+class RawData(_RawData):
     """
     A class for storing the "raw data" information for a
     muon nexus v2 file
@@ -27,45 +89,59 @@ class RawData(HDF5):
         :param end_time: the end time of the experiment
         :param ID: a string identifier for the experiment
         """
-        super().__init__()
+        super().__init__(IDF, definition, inst, title, notes,
+                         run_number, duration, raw_frames,
+                         start_time, end_time, ID)
+
         self._dict['good_frames'] = good_frames
-        self._dict['IDF'] = IDF
-        self._dict['def'] = definition
-        self._dict['inst'] = inst
-        self._dict['title'] = title
-        self._dict['notes'] = notes
-        self._dict['run_number'] = run_number
-        self._dict['duration'] = duration
         self._dict['raw_frames'] = raw_frames
-        self._dict['start'] = start_time
-        self._dict['end'] = end_time
-        self._dict['ID'] = ID
 
     def save_nxs2(self, file):
         """
         A method to save the information into a muon nexus v2 file
         :param file: the open file to write to.
         """
-        tmp = file.require_group('raw_data_1')
-        tmp.attrs['NX_class'] = 'NXentry'
+        super().save_nxs2(file,
+                          self._dict['good_frames'],
+                          self._dict['raw_frames'])
 
-        self.save_int('good_frames', self._dict['good_frames'], tmp)
-        self.save_int('IDF_version', self._dict['IDF'], tmp)
-        self.save_str('definition', self._dict['def'], tmp)
-        self.save_str('name', self._dict['inst'], tmp)
-        self.save_str('title', self._dict['title'], tmp)
-        self.save_str('notes', self._dict['notes'], tmp)
-        self.save_int('run_number', self._dict['run_number'], tmp)
-        self.save_float('duration', self._dict['duration'], tmp)
-        self.save_int('raw_frames', self._dict['raw_frames'], tmp)
-        self.save_str('start_time',
-                      convert_date_for_NXS(self._dict['start']),
-                      tmp)
-        self.save_str('end_time', convert_date_for_NXS(self._dict['end']), tmp)
-        self.save_str('experiment_identifier', self._dict['ID'], tmp)
 
-        tmp = tmp.require_group('instrument')
-        self.save_str('name', self._dict['inst'], tmp)
+class EventsRawData(_RawData):
+    """
+    A class for storing the "raw data" information for a
+    muon nexus v2 file
+    """
+    def __init__(self, cache, IDF, definition, inst, title, notes,
+                 run_number, duration, start_time, end_time, ID):
+        """
+        Creates the raw data object, which holds all of the information
+        for the raw data section of a muon nexus v2 file
+        :param cache: the cache for events data
+        :param IDF: the version of the Instrument Definition File (IDF)
+        :param definition: the definition (e.g. pulsedTD)
+        :param inst: the instrument name
+        :param title: the title of the experiment
+        :param notes: the additional notes/comments
+        :param run_number: the run number
+        :param duration: the duration of the experiment
+        :param start_time: the start time of the experiment
+        :param end_time: the end time of the experiment
+        :param ID: a string identifier for the experiment
+        """
+        super().__init__(IDF, definition, inst, title, notes,
+                         run_number, duration, start_time,
+                         end_time, ID)
+
+        self._cache = cache
+
+    def save_nxs2(self, file):
+        """
+        A method to save the information into a muon nexus v2 file
+        :param file: the open file to write to.
+        """
+        super().save_nxs2(file,
+                          self._cache.get_total_frames(),
+                          self._cache.get_total_frames())
 
 
 def read_raw_data_from_histogram(file):

--- a/src/MuonDataLib/data/raw_data.py
+++ b/src/MuonDataLib/data/raw_data.py
@@ -140,7 +140,7 @@ class EventsRawData(_RawData):
         :param file: the open file to write to.
         """
         super().save_nxs2(file,
-                          self._cache.get_total_frames(),
+                          self._cache.get_good_frames(),
                           self._cache.get_total_frames())
 
 

--- a/src/MuonDataLib/data/raw_data.py
+++ b/src/MuonDataLib/data/raw_data.py
@@ -90,7 +90,7 @@ class RawData(_RawData):
         :param ID: a string identifier for the experiment
         """
         super().__init__(IDF, definition, inst, title, notes,
-                         run_number, duration, raw_frames,
+                         run_number, duration,
                          start_time, end_time, ID)
 
         self._dict['good_frames'] = good_frames

--- a/src/MuonDataLib/data/raw_data.py
+++ b/src/MuonDataLib/data/raw_data.py
@@ -140,8 +140,8 @@ class EventsRawData(_RawData):
         :param file: the open file to write to.
         """
         super().save_nxs2(file,
-                          self._cache.get_good_frames(),
-                          self._cache.get_total_frames())
+                          self._cache.get_good_frames()[0],
+                          self._cache.get_total_frames()[0])
 
 
 def read_raw_data_from_histogram(file):

--- a/src/MuonDataLib/test_helpers/detector1.py
+++ b/src/MuonDataLib/test_helpers/detector1.py
@@ -1,0 +1,255 @@
+from MuonDataLib.data.detector1 import read_detector1_from_histogram
+
+import h5py
+import os
+import numpy as np
+
+
+class Det1TestTemplate(object):
+
+    """
+    ---------IMPORTANT-------------------------------
+    When inheriting this class, you will also need to
+    inherit "unittest.TestCase" or "TestHelper" for it
+    to work as a unit test. Cannot do it here as it
+    will then treat this base class as a test
+    (which will always fail).
+    -------------------------------------------------
+    """
+
+    def create_single_period_data(self):
+        x = [1., 2., 3.]
+        # counts: shape(periods, spec, x)
+        counts = []
+        for p in range(1):
+            counts.append([])
+            for j in range(4):
+                tmp = (((j + 1) * np.ones(len(x))))
+                counts[p].append([int(x) for x in tmp])
+
+        return 1, x, [4, 5, 6, 7], counts, 'python', 3, 4, 42
+
+    def create_multiperiod_data(self):
+        x = [1., 2., 3.]
+        # counts: shape(periods, spec, x)
+        counts = []
+        for p in range(3):
+            counts.append([])
+            for j in range(2):
+                tmp = (((p + 1) * np.ones(len(x))))
+                counts[p].append([int(x) for x in tmp])
+
+        return 1, x, [4, 5], counts, 'python', 3, 4, 42
+
+    def save(self, det, file):
+        raise NotImplementedError()
+
+    def setUp(self):
+        raise NotImplementedError()
+
+    def test_detector1_object_stores_correct_info_single_period(self):
+        """
+        Check the class stores data correctly
+        """
+        det = self.create_single_period_data()
+
+        self.assertEqual(det._dict['resolution'], 1)
+        self.assertEqual(det._dict['last_good'], 42)
+        self.assertArrays(det._dict['spectrum_index'], [4, 5, 6, 7])
+        self.assertEqual(det._dict['inst'], 'python')
+        self.assertEqual(det._dict['time_zero'], 3)
+        self.assertEqual(det._dict['first_good'], 4)
+        self.assertEqual(det._dict['last_good'], 42)
+
+        self.det = det
+
+    def test_detector1_object_saves_correct_info_single_period(self):
+        """
+        Test that the class can save to a nexus file
+        correctly
+        """
+        det = self.create_single_period_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(det, file)
+
+        with h5py.File(self.filename, 'r') as file:
+            keys = self.compare_keys(file, ['raw_data_1'])
+            inst = file[keys[0]]
+
+            keys = self.compare_keys(inst, ['instrument'])
+            inst = inst[keys[0]]
+            self.assertEqual(inst.attrs['NX_class'], 'NXinstrument')
+
+            keys = self.compare_keys(inst, ['detector_1'])
+            group = inst[keys[0]]
+            self.assertEqual(group.attrs['NX_class'], 'NXdetector')
+
+            keys = self.compare_keys(group, ['resolution',
+                                             'raw_time',
+                                             'spectrum_index',
+                                             'counts',
+                                             ])
+
+            # check values
+            self.assertEqual(group['resolution'][0], 1e6)
+            self.assertArrays(group['raw_time'][:], [1., 2., 3.])
+            self.assertArrays(group['spectrum_index'][:], [4, 5, 6, 7])
+            self.assertArrays(group['counts'][:], [
+                                                   [[1, 1, 1],
+                                                    [2, 2, 2],
+                                                    [3, 3, 3],
+                                                    [4, 4, 4]]])
+
+            # check attributes
+            tmp = group['resolution']
+            self.assertEqual(tmp.attrs['units'].decode(), "picoseconds")
+
+            tmp = group['raw_time']
+            self.assertEqual(tmp.attrs['units'].decode(), 'microseconds')
+            self.assertEqual(tmp.attrs['long_name'].decode(), 'time')
+
+            tmp = group['counts']
+            self.assertEqual(tmp.attrs['axes'].decode(),
+                             '[period index, spectrum index, raw time bin]')
+            self.assertEqual(tmp.attrs['long_name'].decode(), 'python')
+            self.assertEqual(tmp.attrs['t0_bin'], 3)
+            self.assertEqual(tmp.attrs['first_good_bin'], 4)
+            self.assertEqual(tmp.attrs['last_good_bin'], 42)
+
+    def test_load_detector1_gets_correct_info_single_period(self):
+        """
+        Check load method gets the correct information.
+        The above tests prove that the information
+        stored is correct and that it is correctly
+        written to file.
+        """
+        det = self.create_single_period_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(det, file)
+        del det
+
+        with h5py.File(self.filename, 'r') as file:
+            load_det = read_detector1_from_histogram(file)
+
+        self.assertEqual(load_det._dict['resolution'], 1)
+        self.assertArrays(load_det._dict['spectrum_index'], [4, 5, 6, 7])
+        self.assertEqual(load_det._dict['inst'], 'python')
+        self.assertEqual(load_det._dict['time_zero'], 3)
+        self.assertEqual(load_det._dict['first_good'], 4)
+        self.assertEqual(load_det._dict['last_good'], 42)
+        self.assertArrays(load_det._dict['raw_time'], [1, 2, 3])
+        self.assertArrays(load_det._dict['counts'], [
+                                                          [[1, 1, 1],
+                                                           [2, 2, 2],
+                                                           [3, 3, 3],
+                                                           [4, 4, 4]]])
+        self.assertEqual(load_det.N_x, 3)
+        self.assertEqual(load_det.N_hist, 4)
+        self.assertEqual(load_det.N_periods, 1)
+
+        os.remove(self.filename)
+
+    def test_detector1_object_stores_correct_info_multiperiod(self):
+        """
+        Check the class stores data correctly
+        """
+        det = self.create_multiperiod_data()
+
+        self.assertEqual(det._dict['resolution'], 1)
+        self.assertArrays(det._dict['spectrum_index'], [4, 5])
+        self.assertEqual(det._dict['inst'], 'python')
+        self.assertEqual(det._dict['time_zero'], 3)
+        self.assertEqual(det._dict['first_good'], 4)
+        self.assertEqual(det._dict['last_good'], 42)
+
+        self.det = det
+
+    def test_detector1_object_saves_correct_info_multiperiod(self):
+        """
+        Test that the class can save to a nexus file
+        correctly
+        """
+        det = self.create_multiperiod_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(det, file)
+
+        with h5py.File(self.filename, 'r') as file:
+            keys = self.compare_keys(file, ['raw_data_1'])
+            inst = file[keys[0]]
+
+            keys = self.compare_keys(inst, ['instrument'])
+            inst = inst[keys[0]]
+            self.assertEqual(inst.attrs['NX_class'], 'NXinstrument')
+
+            keys = self.compare_keys(inst, ['detector_1'])
+            group = inst[keys[0]]
+            self.assertEqual(group.attrs['NX_class'], 'NXdetector')
+
+            keys = self.compare_keys(group, ['resolution',
+                                             'raw_time',
+                                             'spectrum_index',
+                                             'counts',
+                                             ])
+
+            # check values
+            self.assertEqual(group['resolution'][0], 1e6)
+            self.assertArrays(group['raw_time'][:], [1., 2., 3.])
+            self.assertArrays(group['spectrum_index'][:], [4, 5])
+            self.assertArrays(group['counts'][:], [
+                                                   [[1, 1, 1], [1, 1, 1]],
+                                                   [[2, 2, 2], [2, 2, 2]],
+                                                   [[3, 3, 3], [3, 3, 3]]])
+
+            # check attributes
+            tmp = group['resolution']
+            self.assertEqual(tmp.attrs['units'].decode(), "picoseconds")
+
+            tmp = group['raw_time']
+            self.assertEqual(tmp.attrs['units'].decode(), 'microseconds')
+            self.assertEqual(tmp.attrs['long_name'].decode(), 'time')
+
+            tmp = group['counts']
+            self.assertEqual(tmp.attrs['axes'].decode(),
+                             '[period index, spectrum index, raw time bin]')
+            self.assertEqual(tmp.attrs['long_name'].decode(), 'python')
+            self.assertEqual(tmp.attrs['t0_bin'], 3)
+            self.assertEqual(tmp.attrs['first_good_bin'], 4)
+            self.assertEqual(tmp.attrs['last_good_bin'], 42)
+        os.remove(self.filename)
+
+    def test_load_detector1_gets_correct_info_multiperiod(self):
+        """
+        Check load method gets the correct information.
+        The above tests prove that the information
+        stored is correct and that it is correctly
+        written to file.
+        """
+        det = self.create_multiperiod_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(det, file)
+        del det
+
+        with h5py.File(self.filename, 'r') as file:
+            load_det = read_detector1_from_histogram(file)
+
+        self.assertEqual(load_det._dict['resolution'], 1)
+        self.assertArrays(load_det._dict['spectrum_index'], [4, 5])
+        self.assertEqual(load_det._dict['inst'], 'python')
+        self.assertEqual(load_det._dict['time_zero'], 3)
+        self.assertEqual(load_det._dict['first_good'], 4)
+        self.assertEqual(load_det._dict['last_good'], 42)
+        self.assertArrays(load_det._dict['raw_time'], [1., 2., 3.])
+        self.assertArrays(load_det._dict['counts'], [
+                                                     [[1, 1, 1], [1, 1, 1]],
+                                                     [[2, 2, 2], [2, 2, 2]],
+                                                     [[3, 3, 3], [3, 3, 3]]])
+
+        self.assertEqual(load_det.N_x, 3)
+        self.assertEqual(load_det.N_hist, 2)
+        self.assertEqual(load_det.N_periods, 3)
+
+        os.remove(self.filename)

--- a/src/MuonDataLib/test_helpers/periods.py
+++ b/src/MuonDataLib/test_helpers/periods.py
@@ -16,11 +16,11 @@ class PeriodsTestTemplate(object):
     -------------------------------------------------
     """
     def create_single_period_data(self):
-        return 1, 'period 1', [1], [500], [1000], [1], [1.23], [2]
+        return 1, 'period 1', [1], [500], [1000], [1], [12], [2]
 
     def create_multiperiod_data(self):
         return (2, 'period 1; period 2', [1, 2], [500, 400],
-                [1000, 500], [1, 0], [1.23, 4.56], [42, 42])
+                [1000, 500], [1, 0], [12, 45], [42, 42])
 
     def save(self, periods, file):
         raise NotImplementedError()
@@ -66,7 +66,7 @@ class PeriodsTestTemplate(object):
             self.assertArrays(group['raw_frames'], [1000])
             self.assertArrays(group['output'], [1])
             self.assertArrays(group['sequences'], [2])
-            self.assertArrays(group['total_counts'], [1.23])
+            self.assertArrays(group['total_counts'], [12])
 
         os.remove(self.filename)
 
@@ -93,7 +93,7 @@ class PeriodsTestTemplate(object):
         self.assertArrays(load_period._dict['raw'], [1000])
         self.assertArrays(load_period._dict['output'], [1])
         self.assertArrays(load_period._dict['sequences'], [2])
-        self.assertArrays(load_period._dict['counts'], [1.23])
+        self.assertArrays(load_period._dict['counts'], [12])
 
         os.remove(self.filename)
 
@@ -135,11 +135,11 @@ class PeriodsTestTemplate(object):
             self.assertArrays(group['raw_frames'], [1000, 500])
             self.assertArrays(group['output'], [1, 0])
             self.assertArrays(group['sequences'], [42, 42])
-            self.assertArrays(group['total_counts'], [1.23, 4.56])
+            self.assertArrays(group['total_counts'], [12, 45])
 
         os.remove(self.filename)
 
-    def test_load_detector1_gets_correct_info_multiperiod(self):
+    def test_load_period_gets_correct_info_multiperiod(self):
         """
         Check load method gets the correct information.
         The above tests prove that the information
@@ -162,6 +162,6 @@ class PeriodsTestTemplate(object):
         self.assertArrays(load_period._dict['raw'], [1000, 500])
         self.assertArrays(load_period._dict['output'], [1, 0])
         self.assertArrays(load_period._dict['sequences'], [42, 42])
-        self.assertArrays(load_period._dict['counts'], [1.23, 4.56])
+        self.assertArrays(load_period._dict['counts'], [12, 45])
 
         os.remove(self.filename)

--- a/src/MuonDataLib/test_helpers/periods.py
+++ b/src/MuonDataLib/test_helpers/periods.py
@@ -16,11 +16,11 @@ class PeriodsTestTemplate(object):
     -------------------------------------------------
     """
     def create_single_period_data(self):
-        return 1, 'period 1', [1], [500], [1000], [1], [12], [2]
+        return 1, 'period 1', [1], [500], [1000], [1], [1.2e-5], [2]
 
     def create_multiperiod_data(self):
         return (2, 'period 1; period 2', [1, 2], [500, 400],
-                [1000, 500], [1, 0], [12, 45], [42, 42])
+                [1000, 500], [1, 0], [1.2e-5, 4.5e-5], [42, 42])
 
     def save(self, periods, file):
         raise NotImplementedError()
@@ -66,7 +66,7 @@ class PeriodsTestTemplate(object):
             self.assertArrays(group['raw_frames'], [1000])
             self.assertArrays(group['output'], [1])
             self.assertArrays(group['sequences'], [2])
-            self.assertArrays(group['total_counts'], [12])
+            self.assertArrays(group['total_counts'], [12.e-6])
 
         os.remove(self.filename)
 
@@ -93,7 +93,7 @@ class PeriodsTestTemplate(object):
         self.assertArrays(load_period._dict['raw'], [1000])
         self.assertArrays(load_period._dict['output'], [1])
         self.assertArrays(load_period._dict['sequences'], [2])
-        self.assertArrays(load_period._dict['counts'], [12])
+        self.assertArrays(load_period._dict['total_counts'], [12.e-6])
 
         os.remove(self.filename)
 
@@ -135,7 +135,7 @@ class PeriodsTestTemplate(object):
             self.assertArrays(group['raw_frames'], [1000, 500])
             self.assertArrays(group['output'], [1, 0])
             self.assertArrays(group['sequences'], [42, 42])
-            self.assertArrays(group['total_counts'], [12, 45])
+            self.assertArrays(group['total_counts'], [12.e-6, 45.e-6])
 
         os.remove(self.filename)
 
@@ -162,6 +162,6 @@ class PeriodsTestTemplate(object):
         self.assertArrays(load_period._dict['raw'], [1000, 500])
         self.assertArrays(load_period._dict['output'], [1, 0])
         self.assertArrays(load_period._dict['sequences'], [42, 42])
-        self.assertArrays(load_period._dict['counts'], [12, 45])
+        self.assertArrays(load_period._dict['total_counts'], [12.e-6, 45.e-6])
 
         os.remove(self.filename)

--- a/src/MuonDataLib/test_helpers/periods.py
+++ b/src/MuonDataLib/test_helpers/periods.py
@@ -1,0 +1,167 @@
+from MuonDataLib.data.periods import read_periods_from_histogram
+
+import os
+import h5py
+
+
+class PeriodsTestTemplate(object):
+
+    """
+    ---------IMPORTANT-------------------------------
+    When inheriting this class, you will also need to
+    inherit "unittest.TestCase" or "TestHelper" for it
+    to work as a unit test. Cannot do it here as it
+    will then treat this base class as a test
+    (which will always fail).
+    -------------------------------------------------
+    """
+    def create_single_period_data(self):
+        return 1, 'period 1', [1], [500], [1000], [1], [1.23], [2]
+
+    def create_multiperiod_data(self):
+        return (2, 'period 1; period 2', [1, 2], [500, 400],
+                [1000, 500], [1, 0], [1.23, 4.56], [42, 42])
+
+    def save(self, periods, file):
+        raise NotImplementedError()
+
+    def setUp(self):
+        raise NotImplementedError()
+
+    def test_periods_object_stores_correct_info_single_period(self):
+        """
+        Check the class stores data correctly
+        """
+        period = self.create_single_period_data()
+
+        self.assertEqual(period._dict['number'], 1)
+        self.assertEqual(period._dict['labels'], 'period 1')
+        self.assertArrays(period._dict['type'], [1])
+        self.assertArrays(period._dict['output'], [1])
+        self.assertArrays(period._dict['sequences'], [2])
+
+        self.period = period
+
+    def test_periods_object_saves_correct_info_single_period(self):
+        """
+        Test that the class can save to a nexus file
+        correctly
+        """
+        periods = self.create_single_period_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(periods, file)
+
+        with h5py.File(self.filename, 'r') as file:
+            keys = self.compare_keys(file, ['raw_data_1'])
+            group = file[keys[0]]
+            keys = self.compare_keys(group, ['periods'])
+            group = group[keys[0]]
+            self.assertEqual(group.attrs['NX_class'], 'NXperiod')
+
+            self.assertEqual(group['number'][0], 1)
+            self.assertString(group, 'labels', 'period 1')
+            self.assertArrays(group['type'], [1])
+            self.assertArrays(group['frames_requested'], [500])
+            self.assertArrays(group['raw_frames'], [1000])
+            self.assertArrays(group['output'], [1])
+            self.assertArrays(group['sequences'], [2])
+            self.assertArrays(group['total_counts'], [1.23])
+
+        os.remove(self.filename)
+
+    def test_load_periods_gets_correct_info_single_period(self):
+        """
+        Check load method gets the correct information.
+        The above tests prove that the information
+        stored is correct and that it is correctly
+        written to file.
+        """
+        period = self.create_single_period_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(period, file)
+        del period
+
+        with h5py.File(self.filename, 'r') as file:
+            load_period = read_periods_from_histogram(file)
+
+        self.assertEqual(load_period._dict['number'], 1)
+        self.assertEqual(load_period._dict['labels'], 'period 1')
+        self.assertArrays(load_period._dict['type'], [1])
+        self.assertArrays(load_period._dict['requested'], [500])
+        self.assertArrays(load_period._dict['raw'], [1000])
+        self.assertArrays(load_period._dict['output'], [1])
+        self.assertArrays(load_period._dict['sequences'], [2])
+        self.assertArrays(load_period._dict['counts'], [1.23])
+
+        os.remove(self.filename)
+
+    def test_periods_object_stores_correct_info_multiperiod(self):
+        """
+        Check the class stores data correctly
+        """
+        period = self.create_multiperiod_data()
+
+        self.assertEqual(period._dict['number'], 2)
+        self.assertEqual(period._dict['labels'], 'period 1; period 2')
+        self.assertArrays(period._dict['type'], [1, 2])
+        self.assertArrays(period._dict['output'], [1, 0])
+        self.assertArrays(period._dict['sequences'], [42, 42])
+
+        self.period = period
+
+    def test_periods_object_saves_correct_info_multiperiod(self):
+        """
+        Test that the class can save to a nexus file
+        correctly
+        """
+        period = self.create_multiperiod_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(period, file)
+
+        with h5py.File(self.filename, 'r') as file:
+            keys = self.compare_keys(file, ['raw_data_1'])
+            group = file[keys[0]]
+            keys = self.compare_keys(group, ['periods'])
+            group = group[keys[0]]
+            self.assertEqual(group.attrs['NX_class'], 'NXperiod')
+
+            self.assertEqual(group['number'][0], 2)
+            self.assertEqual(group['labels'][0].decode(), 'period 1; period 2')
+            self.assertArrays(group['type'], [1, 2])
+            self.assertArrays(group['frames_requested'], [500, 400])
+            self.assertArrays(group['raw_frames'], [1000, 500])
+            self.assertArrays(group['output'], [1, 0])
+            self.assertArrays(group['sequences'], [42, 42])
+            self.assertArrays(group['total_counts'], [1.23, 4.56])
+
+        os.remove(self.filename)
+
+    def test_load_detector1_gets_correct_info_multiperiod(self):
+        """
+        Check load method gets the correct information.
+        The above tests prove that the information
+        stored is correct and that it is correctly
+        written to file.
+        """
+        period = self.create_multiperiod_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(period, file)
+        del period
+
+        with h5py.File(self.filename, 'r') as file:
+            load_period = read_periods_from_histogram(file)
+
+        self.assertEqual(load_period._dict['number'], 2)
+        self.assertEqual(load_period._dict['labels'], 'period 1; period 2')
+        self.assertArrays(load_period._dict['type'], [1, 2])
+        self.assertArrays(load_period._dict['requested'], [500, 400])
+        self.assertArrays(load_period._dict['raw'], [1000, 500])
+        self.assertArrays(load_period._dict['output'], [1, 0])
+        self.assertArrays(load_period._dict['sequences'], [42, 42])
+        self.assertArrays(load_period._dict['counts'], [1.23, 4.56])
+
+        os.remove(self.filename)

--- a/src/MuonDataLib/test_helpers/raw_data.py
+++ b/src/MuonDataLib/test_helpers/raw_data.py
@@ -1,0 +1,130 @@
+from MuonDataLib.data.raw_data import read_raw_data_from_histogram
+
+import h5py
+import os
+import datetime
+
+
+class RawDataTestTemplate(object):
+
+    """
+    ---------IMPORTANT-------------------------------
+    When inheriting this class, you will also need to
+    inherit "unittest.TestCase" or "TestHelper" for it
+    to work as a unit test. Cannot do it here as it
+    will then treat this base class as a test
+    (which will always fail).
+    -------------------------------------------------
+    """
+    def create_data(self):
+        start = datetime.datetime(2018, 12, 24, 13, 32, 1)
+        end = datetime.datetime(2018, 12, 24, 18, 11, 52)
+
+        return (10, 1, 'pulsed', 'python', 'raw data test',
+                    'testing', 42, 1024.0, 51, start, end, '19')
+
+    def save(self, raw, file):
+        raise NotImplementedError()
+
+    def setUp(self):
+        raise NotImplementedError()
+
+    def test_raw_data_object_stores_correct_info(self):
+        """
+        Check the class stores data correctly
+        """
+        raw, start, end = self.create_data()
+
+        self.assertEqual(raw._dict['IDF'], 1)
+        self.assertEqual(raw._dict['def'], 'pulsed')
+        self.assertEqual(raw._dict['inst'], 'python')
+        self.assertEqual(raw._dict['title'], 'raw data test')
+        self.assertEqual(raw._dict['notes'], 'testing')
+        self.assertEqual(raw._dict['run_number'], 42)
+        self.assertAlmostEqual(raw._dict['duration'], 1024.0, 3)
+        self.assertEqual(raw._dict['start'], start)
+        self.assertEqual(raw._dict['end'], end)
+
+        self.raw = raw
+
+    def test_raw_data_object_saves_correct_info(self):
+        """
+        Test that the class can save to a nexus file
+        correctly
+        """
+        raw, _, _ = self.create_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(raw, file)
+
+        with h5py.File(self.filename, 'r') as file:
+            keys = self.compare_keys(file, ['raw_data_1'])
+            group = file[keys[0]]
+            self.assertEqual(group.attrs['NX_class'], 'NXentry')
+
+            keys = self.compare_keys(group, ['good_frames',
+                                             'IDF_version',
+                                             'definition',
+                                             'name',
+                                             'title',
+                                             'notes',
+                                             'run_number',
+                                             'duration',
+                                             'raw_frames',
+                                             'start_time',
+                                             'end_time',
+                                             'experiment_identifier',
+                                             'instrument'])
+
+            self.assertArrays(group['good_frames'], [10])
+            self.assertArrays(group['IDF_version'], [1])
+            self.assertString(group, 'definition', 'pulsed')
+            self.assertString(group, 'name', 'python')
+            self.assertString(group, 'title', 'raw data test')
+            self.assertString(group, 'notes', 'testing')
+            self.assertArrays(group['run_number'], [42])
+            self.assertArrays(group['duration'], [1024.0])
+            self.assertArrays(group['raw_frames'], [51])
+            self.assertString(group, 'start_time', '2018-12-24T13:32:01')
+            self.assertString(group, 'end_time', '2018-12-24T18:11:52')
+
+            group = group['instrument']
+            self.compare_keys(group, ['name'])
+            self.assertString(group, 'name', 'python')
+
+        os.remove(self.filename)
+
+    def test_load_raw_data_gets_correct_info(self):
+        """
+        Check load method gets the correct information.
+        The above tests prove that the information
+        stored is correct and that it is correctly
+        written to file.
+        """
+        raw, start, end = self.create_data()
+
+        with h5py.File(self.filename, 'w') as file:
+            self.save(raw, file)
+
+        del raw
+
+        with h5py.File(self.filename, 'r') as file:
+            load_raw = read_raw_data_from_histogram(file)
+
+        self.assertEqual(load_raw._dict['good_frames'], 10)
+        self.assertEqual(load_raw._dict['IDF'], 1)
+        self.assertEqual(load_raw._dict['def'], 'pulsed')
+        self.assertEqual(load_raw._dict['inst'], 'python')
+        self.assertEqual(load_raw._dict['title'], 'raw data test')
+        self.assertEqual(load_raw._dict['notes'], 'testing')
+        self.assertEqual(load_raw._dict['run_number'], 42)
+        self.assertAlmostEqual(load_raw._dict['duration'], 1024.0, 3)
+        self.assertEqual(load_raw._dict['raw_frames'], 51)
+        self.assertEqual(load_raw._dict['start'], start)
+        self.assertEqual(load_raw._dict['end'], end)
+
+        os.remove(self.filename)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/MuonDataLib/test_helpers/raw_data.py
+++ b/src/MuonDataLib/test_helpers/raw_data.py
@@ -21,7 +21,7 @@ class RawDataTestTemplate(object):
         end = datetime.datetime(2018, 12, 24, 18, 11, 52)
 
         return (10, 1, 'pulsed', 'python', 'raw data test',
-                    'testing', 42, 1024.0, 51, start, end, '19')
+                'testing', 42, 1024.0, 51, start, end, '19')
 
     def save(self, raw, file):
         raise NotImplementedError()
@@ -124,7 +124,3 @@ class RawDataTestTemplate(object):
         self.assertEqual(load_raw._dict['end'], end)
 
         os.remove(self.filename)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/test/cython_ext/events_cache_test.py
+++ b/test/cython_ext/events_cache_test.py
@@ -22,11 +22,11 @@ class EventsCacheTest(TestHelper):
         cache.save(np.asarray([[[1, 2, 3],
                                 [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
-                   1)
+                   np.asarray([1], dtype=np.int32))
 
         self.assertFalse(cache.empty())
-        self.assertEqual(cache.get_total_frames(), 1)
-        self.assertEqual(cache.get_good_frames(), 1)
+        self.assertEqual(np.asarray(cache.get_total_frames()), [1])
+        self.assertEqual(np.asarray(cache.get_good_frames()), [1])
         hist, bins = cache.get_histograms()
         self.assertArrays(hist, [[[1, 2, 3],
                                   [4, 5, 6]]])
@@ -39,7 +39,7 @@ class EventsCacheTest(TestHelper):
         cache.save(np.asarray([[[1, 2, 3],
                                 [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
-                   1)
+                   np.asarray([1], dtype=np.int32))
 
         self.assertFalse(cache.empty())
 
@@ -56,13 +56,13 @@ class EventsCacheTest(TestHelper):
         cache.save(np.asarray([[[1, 2, 3],
                                 [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
-                   10)
-        self.assertEqual(cache.get_good_frames(), 10)
+                   np.asarray([10], dtype=np.int32))
+        self.assertEqual(np.asarray(cache.get_good_frames()), [10])
 
-        cache.set_good_frames(5)
+        cache.set_good_frames(np.asarray([5], dtype=np.int32))
 
-        self.assertEqual(cache.get_good_frames(), 5)
-        self.assertEqual(cache.get_total_frames(), 10)
+        self.assertEqual(np.asarray(cache.get_good_frames()), [5])
+        self.assertEqual(np.asarray(cache.get_total_frames()), [10])
 
     def test_set_too_many_good_frames(self):
         cache = EventsCache()
@@ -71,10 +71,10 @@ class EventsCacheTest(TestHelper):
         cache.save(np.asarray([[[1, 2, 3],
                                 [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
-                   1)
+                   np.asarray([1], dtype=np.int32))
 
         with self.assertRaises(RuntimeError):
-            cache.set_good_frames(6)
+            cache.set_good_frames(np.asarray([1, 2], dtype=np.int32))
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/events_cache_test.py
+++ b/test/cython_ext/events_cache_test.py
@@ -26,6 +26,7 @@ class EventsCacheTest(TestHelper):
 
         self.assertFalse(cache.empty())
         self.assertEqual(cache.get_total_frames(), 1)
+        self.assertEqual(cache.get_good_frames(), 1)
         hist, bins = cache.get_histograms()
         self.assertArrays(hist, [[[1, 2, 3],
                                   [4, 5, 6]]])
@@ -48,6 +49,32 @@ class EventsCacheTest(TestHelper):
             cache.get_histograms()
         with self.assertRaises(RuntimeError):
             cache.get_total_frames()
+
+    def test_set_good_frames(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+        cache.save(np.asarray([[[1, 2, 3],
+                                [4, 5, 6]]], dtype=np.int32),
+                   np.asarray([7, 8, 9], dtype=np.double),
+                   10)
+        self.assertEqual(cache.get_good_frames(), 10)
+
+        cache.set_good_frames(5)
+
+        self.assertEqual(cache.get_good_frames(), 5)
+        self.assertEqual(cache.get_total_frames(), 10)
+
+    def test_set_too_many_good_frames(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+
+        cache.save(np.asarray([[[1, 2, 3],
+                                [4, 5, 6]]], dtype=np.int32),
+                   np.asarray([7, 8, 9], dtype=np.double),
+                   1)
+
+        with self.assertRaises(RuntimeError):
+            cache.set_good_frames(6)
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/events_cache_test.py
+++ b/test/cython_ext/events_cache_test.py
@@ -1,0 +1,54 @@
+import unittest
+import numpy as np
+
+from MuonDataLib.test_helpers.unit_test import TestHelper
+from MuonDataLib.cython_ext.events_cache import EventsCache
+
+
+class EventsCacheTest(TestHelper):
+
+    def test_create_empty_cache(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+        with self.assertRaises(RuntimeError):
+            cache.get_histograms()
+        with self.assertRaises(RuntimeError):
+            cache.get_total_frames()
+
+    def test_save_to_cache(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+
+        cache.save(np.asarray([[[1, 2, 3],
+                                [4, 5, 6]]]),
+                   np.asarray([7, 8, 9], dtype=np.double),
+                   1)
+
+        self.assertFalse(cache.empty())
+        self.assertEqual(cache.get_total_frames(), 1)
+        hist, bins = cache.get_histograms()
+        self.assertArrays(hist, [[[1, 2, 3],
+                                  [4, 5, 6]]])
+        self.assertArrays(bins, [7, 8, 9])
+
+    def test_clear_cache(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+
+        cache.save(np.asarray([[[1, 2, 3],
+                                [4, 5, 6]]]),
+                   np.asarray([7, 8, 9], dtype=np.double),
+                   1)
+
+        self.assertFalse(cache.empty())
+
+        cache.clear()
+        self.assertTrue(cache.empty())
+        with self.assertRaises(RuntimeError):
+            cache.get_histograms()
+        with self.assertRaises(RuntimeError):
+            cache.get_total_frames()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/cython_ext/events_cache_test.py
+++ b/test/cython_ext/events_cache_test.py
@@ -20,7 +20,7 @@ class EventsCacheTest(TestHelper):
         self.assertTrue(cache.empty())
 
         cache.save(np.asarray([[[1, 2, 3],
-                                [4, 5, 6]]]),
+                                [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
                    1)
 
@@ -36,7 +36,7 @@ class EventsCacheTest(TestHelper):
         self.assertTrue(cache.empty())
 
         cache.save(np.asarray([[[1, 2, 3],
-                                [4, 5, 6]]]),
+                                [4, 5, 6]]], dtype=np.int32),
                    np.asarray([7, 8, 9], dtype=np.double),
                    1)
 

--- a/test/cython_ext/events_test.py
+++ b/test/cython_ext/events_test.py
@@ -14,7 +14,8 @@ class EventsTest(TestHelper):
         self._frame_i = np.asarray([0, 3], dtype='int32')
         self._events = Events(self._IDs,
                               self._time,
-                              self._frame_i)
+                              self._frame_i,
+                              2)
 
     def test_get_N_spec(self):
         self.assertEqual(self._events.get_N_spec, 2)

--- a/test/cython_ext/events_test.py
+++ b/test/cython_ext/events_test.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from MuonDataLib.test_helpers.unit_test import TestHelper
 from MuonDataLib.cython_ext.event_data import Events
+from MuonDataLib.cython_ext.events_cache import EventsCache
 
 
 class EventsTest(TestHelper):
@@ -23,6 +24,9 @@ class EventsTest(TestHelper):
     def test_get_N_events(self):
         self.assertEqual(self._events.get_N_events, 6)
 
+    def test_get_total_frames(self):
+        self.assertEqual(self._events.get_total_frames, 2)
+
     def test_histogram(self):
         """
         We dont check the histograms themselves
@@ -33,6 +37,28 @@ class EventsTest(TestHelper):
         mat, bins = self._events.histogram()
         self.assertArrays(bins, np.arange(0, 32.784, 0.016))
         self.assertEqual(len(mat), 2)
+
+    def test_custom_histogram(self):
+        """
+        We dont check the histograms themselves
+        as the stats_test.py covers them.
+        Here we are checking that the correct values
+        are passed to the histogram generation
+        """
+        mat, bins = self._events.histogram(1.2, 4.2, .2)
+        self.assertArrays(bins, np.arange(1.2, 4.4, 0.2))
+        self.assertEqual(len(mat), 2)
+
+    def test_cache_histogram(self):
+        cache = EventsCache()
+        self.assertTrue(cache.empty())
+        mat, bins = self._events.histogram(1.2, 4.2, .2, cache)
+
+        self.assertFalse(cache.empty())
+        c_mat, c_bins = cache.get_histograms()
+        self.assertArrays(bins, c_bins)
+        # cache adds a list for periods, need to remove it
+        self.assertEqual(len(mat), len(c_mat[0]))
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/events_test.py
+++ b/test/cython_ext/events_test.py
@@ -31,7 +31,7 @@ class EventsTest(TestHelper):
         are passed to the histogram generation
         """
         mat, bins = self._events.histogram()
-        self.assertArrays(bins, np.arange(0, 32.768, 0.016))
+        self.assertArrays(bins, np.arange(0, 32.784, 0.016))
         self.assertEqual(len(mat), 2)
 
 

--- a/test/cython_ext/events_test.py
+++ b/test/cython_ext/events_test.py
@@ -23,10 +23,6 @@ class EventsTest(TestHelper):
     def test_get_N_events(self):
         self.assertEqual(self._events.get_N_events, 6)
 
-    def test_get_filtered_events(self):
-        self.assertArrays(self._events.get_filtered_events,
-                          self._IDs)
-
     def test_histogram(self):
         """
         We dont check the histograms themselves
@@ -35,7 +31,7 @@ class EventsTest(TestHelper):
         are passed to the histogram generation
         """
         mat, bins = self._events.histogram()
-        self.assertArrays(bins, np.arange(0, 30.5, 0.5))
+        self.assertArrays(bins, np.arange(0, 32.768, 0.016))
         self.assertEqual(len(mat), 2)
 
 

--- a/test/cython_ext/load_events_test.py
+++ b/test/cython_ext/load_events_test.py
@@ -3,6 +3,7 @@ from unittest import mock
 import os
 import time
 from MuonDataLib.cython_ext.load_events import load_data, _load_data
+from MuonDataLib.cython_ext.events_cache import EventsCache
 from MuonDataLib.test_helpers.unit_test import TestHelper
 
 
@@ -55,8 +56,8 @@ class LoadEventDataTest(TestHelper):
 
         events_mock.return_value = mock.Mock()
         load_mock.side_effect = fake_load
-
-        time_taken, events = load_data('test.nxs')
+        cache = EventsCache()
+        time_taken, events = load_data('test.nxs', cache)
         load_mock.assert_called_once_with("test.nxs")
         self.assertGreater(time_taken, 1.)
         events_mock.assert_called_once_with(IDs, times, start_j)

--- a/test/cython_ext/load_events_test.py
+++ b/test/cython_ext/load_events_test.py
@@ -50,14 +50,14 @@ class LoadEventDataTest(TestHelper):
 
         def fake_load(file_name):
             # add a sleep so we can test the timer
-            time.sleep(1)
+            time.sleep(1.0)
             return IDs, start_j, times, amps, start_t
 
         events_mock.return_value = mock.Mock()
         load_mock.side_effect = fake_load
         time_taken, events = load_data('test.nxs', 2)
         load_mock.assert_called_once_with("test.nxs")
-        self.assertGreater(time_taken, 1.)
+        self.assertGreater(time_taken, 0.99)
         events_mock.assert_called_once_with(IDs, times, start_j, 2)
 
 

--- a/test/cython_ext/load_events_test.py
+++ b/test/cython_ext/load_events_test.py
@@ -60,7 +60,7 @@ class LoadEventDataTest(TestHelper):
         time_taken, events = load_data('test.nxs', cache)
         load_mock.assert_called_once_with("test.nxs")
         self.assertGreater(time_taken, 1.)
-        events_mock.assert_called_once_with(IDs, times, start_j)
+        events_mock.assert_called_once_with(IDs, times, start_j, cache)
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/load_events_test.py
+++ b/test/cython_ext/load_events_test.py
@@ -3,7 +3,6 @@ from unittest import mock
 import os
 import time
 from MuonDataLib.cython_ext.load_events import load_data, _load_data
-from MuonDataLib.cython_ext.events_cache import EventsCache
 from MuonDataLib.test_helpers.unit_test import TestHelper
 
 
@@ -56,11 +55,10 @@ class LoadEventDataTest(TestHelper):
 
         events_mock.return_value = mock.Mock()
         load_mock.side_effect = fake_load
-        cache = EventsCache()
-        time_taken, events = load_data('test.nxs', cache)
+        time_taken, events = load_data('test.nxs', 2)
         load_mock.assert_called_once_with("test.nxs")
         self.assertGreater(time_taken, 1.)
-        events_mock.assert_called_once_with(IDs, times, start_j, cache)
+        events_mock.assert_called_once_with(IDs, times, start_j, 2)
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/stats_test.py
+++ b/test/cython_ext/stats_test.py
@@ -70,7 +70,8 @@ class StatsTest(TestHelper):
                                       conversion=1.)
         self.assertArrays(bins, [0, .1, .2, .3, .4])
         self.assertEqual(len(result), 1)
-        self.assertArrays(result[0], [0, 30, 20, 10])
+        # technically not histograms as the normalisation is done in analysis
+        self.assertArrays(result[0], [0, 3, 2, 1])
 
     def test_make_histogram_conversion(self):
         times = np.asarray([1, 2, 3, 4, 1, 2, 3, 1, 2], dtype=np.double)
@@ -80,7 +81,8 @@ class StatsTest(TestHelper):
                                       1, 0, 0.5, .1, conversion=0.1)
         self.assertArrays(bins, [0, .1, .2, .3, .4, .5])
         self.assertEqual(len(result), 1)
-        self.assertArrays(result[0], [0, 30, 30, 20, 10])
+        # technically not histograms as the normalisation is done in analysis
+        self.assertArrays(result[0], [0, 3, 3, 2, 1])
 
     def test_make_histogram_multi_spec(self):
         times = np.asarray([1, 2, 3, 4, 1, 2, 3, 1, 2], dtype=np.double)

--- a/test/data/detector1_test.py
+++ b/test/data/detector1_test.py
@@ -164,7 +164,6 @@ class Detector1Test(TestHelper):
         self.assertEqual(det._dict['time_zero'], 3)
         self.assertEqual(det._dict['first_good'], 4)
         self.assertEqual(det._dict['last_good'], 42)
-        print(det._dict['counts'])
         self.assertArrays(det._dict['counts'], [
                                                 [[1, 1, 1], [1, 1, 1]],
                                                 [[2, 2, 2], [2, 2, 2]],
@@ -213,7 +212,6 @@ class Detector1Test(TestHelper):
 
             # check attributes
             tmp = group['resolution']
-            print(tmp.attrs['units'])
             self.assertEqual(tmp.attrs['units'].decode(), "picoseconds")
 
             tmp = group['raw_time']

--- a/test/data/detector1_test.py
+++ b/test/data/detector1_test.py
@@ -79,7 +79,7 @@ class EventsDetector1Test(Det1TestTemplate, TestHelper):
                                   args[2], args[4],
                                   args[5], args[6],
                                   args[7])
-        cache.save(counts, bins, 1)
+        cache.save(counts, bins, np.asarray([1], dtype=np.int32))
         return events
 
     def create_multiperiod_data(self):
@@ -91,7 +91,8 @@ class EventsDetector1Test(Det1TestTemplate, TestHelper):
                                   args[2], args[4],
                                   args[5], args[6],
                                   args[7])
-        cache.save(counts, bins, 1)
+        cache.save(counts, bins,
+                   np.asarray([1], dtype=np.int32))
         return events
 
     def setUp(self):

--- a/test/data/detector1_test.py
+++ b/test/data/detector1_test.py
@@ -1,264 +1,139 @@
-from MuonDataLib.data.detector1 import (Detector_1,
-                                        read_detector1_from_histogram)
-
+from MuonDataLib.data.detector1 import (_Detector_1,
+                                        Detector_1,
+                                        EventsDetector_1)
+from MuonDataLib.cython_ext.events_cache import EventsCache
 from MuonDataLib.test_helpers.unit_test import TestHelper
-import h5py
-import os
+from MuonDataLib.test_helpers.detector1 import Det1TestTemplate
 import unittest
 import numpy as np
 
 
-FILENAME = 'detector1_test.nxs'
+class _Detector1Test(Det1TestTemplate, TestHelper):
+
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        self.raw = args[1]
+        self.counts = args[3]
+        return _Detector_1(args[0], args[2], args[4],
+                           args[5], args[6], args[7])
+
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        self.raw = args[1]
+        self.counts = args[3]
+        return _Detector_1(args[0], args[2], args[4],
+                           args[5], args[6], args[7])
+
+    def setUp(self):
+        self.filename = '_detector_1.nxs'
+
+    def save(self, det, file):
+        det.save_nxs2(file, self.raw,
+                      self.counts,
+                      len(self.counts[0][0]),
+                      len(self.counts[0]),
+                      len(self.counts))
 
 
-def create_single_period_data():
-    x = [1., 2., 3.]
-    # counts: shape(periods, spec, x)
-    counts = []
-    for p in range(1):
-        counts.append([])
-        for j in range(4):
-            tmp = (((j + 1) * np.ones(len(x))))
-            counts[p].append([int(x) for x in tmp])
+class Detector1Test(Det1TestTemplate, TestHelper):
 
-    return Detector_1(1, x, [4, 5, 6, 7], counts, 'python', 3, 4, 42)
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        return Detector_1(*args)
 
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        return Detector_1(*args)
 
-def create_multiperiod_data():
-    x = [1., 2., 3.]
-    # counts: shape(periods, spec, x)
-    counts = []
-    for p in range(3):
-        counts.append([])
-        for j in range(2):
-            tmp = (((p + 1) * np.ones(len(x))))
-            counts[p].append([int(x) for x in tmp])
+    def setUp(self):
+        self.filename = 'detector_1.nxs'
 
-    return Detector_1(1, x, [4, 5], counts, 'python', 3, 4, 42)
-
-
-class Detector1Test(TestHelper):
+    def save(self, det, file):
+        det.save_nxs2(file)
 
     def test_detector1_object_stores_correct_info_single_period(self):
         """
         Check the class stores data correctly
         """
-        det = create_single_period_data()
+        super().test_detector1_object_stores_correct_info_single_period()
 
-        self.assertEqual(det._dict['resolution'], 1)
-        self.assertArrays(det._dict['raw_time'], [1, 2, 3])
-        self.assertArrays(det._dict['spectrum_index'], [4, 5, 6, 7])
-        self.assertEqual(det._dict['inst'], 'python')
-        self.assertEqual(det._dict['time_zero'], 3)
-        self.assertEqual(det._dict['first_good'], 4)
-        self.assertEqual(det._dict['last_good'], 42)
-        self.assertArrays(det._dict['counts'], [
-                                                [[1, 1, 1],
-                                                 [2, 2, 2],
-                                                 [3, 3, 3],
-                                                 [4, 4, 4]]])
-        self.assertEqual(det.N_x, 3)
-        self.assertEqual(det.N_hist, 4)
-        self.assertEqual(det.N_periods, 1)
-
-    def test_detector1_object_saves_correct_info_single_period(self):
-        """
-        Test that the class can save to a nexus file
-        correctly
-        """
-        det = create_single_period_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            det.save_nxs2(file)
-
-        with h5py.File(FILENAME, 'r') as file:
-            keys = self.compare_keys(file, ['raw_data_1'])
-            inst = file[keys[0]]
-
-            keys = self.compare_keys(inst, ['instrument'])
-            inst = inst[keys[0]]
-            self.assertEqual(inst.attrs['NX_class'], 'NXinstrument')
-
-            keys = self.compare_keys(inst, ['detector_1'])
-            group = inst[keys[0]]
-            self.assertEqual(group.attrs['NX_class'], 'NXdetector')
-
-            keys = self.compare_keys(group, ['resolution',
-                                             'raw_time',
-                                             'spectrum_index',
-                                             'counts',
-                                             ])
-
-            # check values
-            self.assertEqual(group['resolution'][0], 1e6)
-            self.assertArrays(group['raw_time'][:], [1., 2., 3.])
-            self.assertArrays(group['spectrum_index'][:], [4, 5, 6, 7])
-            self.assertArrays(group['counts'][:], [
-                                                   [[1, 1, 1],
-                                                    [2, 2, 2],
-                                                    [3, 3, 3],
-                                                    [4, 4, 4]]])
-
-            # check attributes
-            tmp = group['resolution']
-            print(tmp.attrs['units'])
-            self.assertEqual(tmp.attrs['units'].decode(), "picoseconds")
-
-            tmp = group['raw_time']
-            self.assertEqual(tmp.attrs['units'].decode(), 'microseconds')
-            self.assertEqual(tmp.attrs['long_name'].decode(), 'time')
-
-            tmp = group['counts']
-            self.assertEqual(tmp.attrs['axes'].decode(),
-                             '[period index, spectrum index, raw time bin]')
-            self.assertEqual(tmp.attrs['long_name'].decode(), 'python')
-            self.assertEqual(tmp.attrs['t0_bin'], 3)
-            self.assertEqual(tmp.attrs['first_good_bin'], 4)
-            self.assertEqual(tmp.attrs['last_good_bin'], 42)
-        os.remove(FILENAME)
-
-    def test_load_detector1_gets_correct_info_single_period(self):
-        """
-        Check load method gets the correct information.
-        The above tests prove that the information
-        stored is correct and that it is correctly
-        written to file.
-        """
-        det = create_single_period_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            det.save_nxs2(file)
-        del det
-
-        with h5py.File(FILENAME, 'r') as file:
-            load_det = read_detector1_from_histogram(file)
-
-        self.assertEqual(load_det._dict['resolution'], 1)
-        self.assertArrays(load_det._dict['raw_time'], [1, 2, 3])
-        self.assertArrays(load_det._dict['spectrum_index'], [4, 5, 6, 7])
-        self.assertEqual(load_det._dict['inst'], 'python')
-        self.assertEqual(load_det._dict['time_zero'], 3)
-        self.assertEqual(load_det._dict['first_good'], 4)
-        self.assertEqual(load_det._dict['last_good'], 42)
-        self.assertArrays(load_det._dict['counts'], [
+        self.assertArrays(self.det._dict['raw_time'], [1, 2, 3])
+        self.assertArrays(self.det._dict['counts'], [
                                                      [[1, 1, 1],
                                                       [2, 2, 2],
                                                       [3, 3, 3],
                                                       [4, 4, 4]]])
-        self.assertEqual(load_det.N_x, 3)
-        self.assertEqual(load_det.N_hist, 4)
-        self.assertEqual(load_det.N_periods, 1)
+        self.assertEqual(self.det.N_x, 3)
+        self.assertEqual(self.det.N_hist, 4)
+        self.assertEqual(self.det.N_periods, 1)
 
-        os.remove(FILENAME)
+
+class EventsDetector1Test(Det1TestTemplate, TestHelper):
+
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        bins = np.asarray(args[1], dtype=np.double)
+        counts = np.asarray(args[3], dtype=np.int32)
+        cache = EventsCache()
+        events = EventsDetector_1(cache, args[0],
+                                  args[2], args[4],
+                                  args[5], args[6],
+                                  args[7])
+        cache.save(counts, bins, 1)
+        return events
+
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        bins = np.asarray(args[1], dtype=np.double)
+        counts = np.asarray(args[3], dtype=np.int32)
+        cache = EventsCache()
+        events = EventsDetector_1(cache, args[0],
+                                  args[2], args[4],
+                                  args[5], args[6],
+                                  args[7])
+        cache.save(counts, bins, 1)
+        return events
+
+    def setUp(self):
+        self.filename = 'events_detector_1.nxs'
+
+    def save(self, det, file):
+        det.save_nxs2(file)
+
+    def test_detector1_object_stores_correct_info_single_period(self):
+        """
+        Check the class stores data correctly
+        """
+        super().test_detector1_object_stores_correct_info_single_period()
+
+        counts, bins = self.det._cache.get_histograms()
+
+        self.assertArrays(bins, [1, 2, 3])
+        self.assertArrays(counts, [
+                                   [[1, 1, 1],
+                                    [2, 2, 2],
+                                    [3, 3, 3],
+                                    [4, 4, 4]]])
+        self.assertEqual(len(counts[0][0]), 3)
+        self.assertEqual(len(counts[0]), 4)
+        self.assertEqual(len(counts), 1)
 
     def test_detector1_object_stores_correct_info_multiperiod(self):
         """
         Check the class stores data correctly
         """
-        det = create_multiperiod_data()
+        super().test_detector1_object_stores_correct_info_multiperiod()
 
-        self.assertEqual(det._dict['resolution'], 1)
-        self.assertArrays(det._dict['raw_time'], [1., 2., 3.])
-        self.assertArrays(det._dict['spectrum_index'], [4, 5])
-        self.assertEqual(det._dict['inst'], 'python')
-        self.assertEqual(det._dict['time_zero'], 3)
-        self.assertEqual(det._dict['first_good'], 4)
-        self.assertEqual(det._dict['last_good'], 42)
-        self.assertArrays(det._dict['counts'], [
-                                                [[1, 1, 1], [1, 1, 1]],
-                                                [[2, 2, 2], [2, 2, 2]],
-                                                [[3, 3, 3], [3, 3, 3]]])
+        counts, bins = self.det._cache.get_histograms()
+        self.assertArrays(bins, [1., 2., 3.])
+        self.assertArrays(counts, [
+                                   [[1, 1, 1], [1, 1, 1]],
+                                   [[2, 2, 2], [2, 2, 2]],
+                                   [[3, 3, 3], [3, 3, 3]]])
 
-        self.assertEqual(det.N_x, 3)
-        self.assertEqual(det.N_hist, 2)
-        self.assertEqual(det.N_periods, 3)
-
-    def test_detector1_object_saves_correct_info_multiperiod(self):
-        """
-        Test that the class can save to a nexus file
-        correctly
-        """
-        det = create_multiperiod_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            det.save_nxs2(file)
-
-        with h5py.File(FILENAME, 'r') as file:
-            keys = self.compare_keys(file, ['raw_data_1'])
-            inst = file[keys[0]]
-
-            keys = self.compare_keys(inst, ['instrument'])
-            inst = inst[keys[0]]
-            self.assertEqual(inst.attrs['NX_class'], 'NXinstrument')
-
-            keys = self.compare_keys(inst, ['detector_1'])
-            group = inst[keys[0]]
-            self.assertEqual(group.attrs['NX_class'], 'NXdetector')
-
-            keys = self.compare_keys(group, ['resolution',
-                                             'raw_time',
-                                             'spectrum_index',
-                                             'counts',
-                                             ])
-
-            # check values
-            self.assertEqual(group['resolution'][0], 1e6)
-            self.assertArrays(group['raw_time'][:], [1., 2., 3.])
-            self.assertArrays(group['spectrum_index'][:], [4, 5])
-            self.assertArrays(group['counts'][:], [
-                                                   [[1, 1, 1], [1, 1, 1]],
-                                                   [[2, 2, 2], [2, 2, 2]],
-                                                   [[3, 3, 3], [3, 3, 3]]])
-
-            # check attributes
-            tmp = group['resolution']
-            self.assertEqual(tmp.attrs['units'].decode(), "picoseconds")
-
-            tmp = group['raw_time']
-            self.assertEqual(tmp.attrs['units'].decode(), 'microseconds')
-            self.assertEqual(tmp.attrs['long_name'].decode(), 'time')
-
-            tmp = group['counts']
-            self.assertEqual(tmp.attrs['axes'].decode(),
-                             '[period index, spectrum index, raw time bin]')
-            self.assertEqual(tmp.attrs['long_name'].decode(), 'python')
-            self.assertEqual(tmp.attrs['t0_bin'], 3)
-            self.assertEqual(tmp.attrs['first_good_bin'], 4)
-            self.assertEqual(tmp.attrs['last_good_bin'], 42)
-        os.remove(FILENAME)
-
-    def test_load_detector1_gets_correct_info_multiperiod(self):
-        """
-        Check load method gets the correct information.
-        The above tests prove that the information
-        stored is correct and that it is correctly
-        written to file.
-        """
-        det = create_multiperiod_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            det.save_nxs2(file)
-        del det
-
-        with h5py.File(FILENAME, 'r') as file:
-            load_det = read_detector1_from_histogram(file)
-
-        self.assertEqual(load_det._dict['resolution'], 1)
-        self.assertArrays(load_det._dict['raw_time'], [1, 2, 3])
-        self.assertArrays(load_det._dict['spectrum_index'], [4, 5])
-        self.assertEqual(load_det._dict['inst'], 'python')
-        self.assertEqual(load_det._dict['time_zero'], 3)
-        self.assertEqual(load_det._dict['first_good'], 4)
-        self.assertEqual(load_det._dict['last_good'], 42)
-        self.assertArrays(load_det._dict['counts'], [
-                                                     [[1, 1, 1], [1, 1, 1]],
-                                                     [[2, 2, 2], [2, 2, 2]],
-                                                     [[3, 3, 3], [3, 3, 3]]])
-        self.assertEqual(load_det.N_x, 3)
-        self.assertEqual(load_det.N_hist, 2)
-        self.assertEqual(load_det.N_periods, 3)
-
-        os.remove(FILENAME)
+        self.assertEqual(len(counts[0][0]), 3)
+        self.assertEqual(len(counts[0]), 2)
+        self.assertEqual(len(counts), 3)
 
 
 if __name__ == '__main__':

--- a/test/data/loader/load_events_test.py
+++ b/test/data/loader/load_events_test.py
@@ -1,0 +1,76 @@
+from MuonDataLib.data.loader.load_events import load_events
+
+import unittest
+from unittest import mock
+import os
+
+
+class LoadEventsTest(unittest.TestCase):
+
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.Sample')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.EventsRawData')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.Source')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.User')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.EventsPeriods')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.Det1')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.MuonEventData')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.EventsCache')
+    @mock.patch('MuonDataLib.data.loader.'
+                'load_events.load_data')
+    def test_load_events(self,
+                         load_data,
+                         cache,
+                         muon_data,
+                         detector_1,
+                         periods,
+                         user,
+                         source,
+                         raw_data,
+                         sample):
+        """
+        Going to check that the function
+        is called correctly by using mocks.
+        The creation of the muon data
+        object is covered by its own tests.
+        """
+        events = mock.Mock()
+        load_data.return_value = (0, events)
+        data_cache = mock.Mock()
+        cache.return_value = data_cache
+        file = os.path.join(os.path.dirname(__file__),
+                            '..',
+                            '..',
+                            'data_files',
+                            'HIFI0.nxs')
+        _ = load_events(file, 64)
+
+        # check the read functions are called
+        sample.assert_called_once()
+        raw_data.assert_called_once()
+        source.assert_called_once()
+        user.assert_called_once()
+        periods.assert_called_once()
+        detector_1.assert_called_once()
+        cache.assert_called_once()
+        load_data.assert_called_once()
+        # check muon data gets the correct read functions
+        muon_data.assert_called_once_with(events,
+                                          data_cache,
+                                          sample=sample(),
+                                          raw_data=raw_data(),
+                                          source=source(),
+                                          user=user(),
+                                          periods=periods(),
+                                          detector1=detector_1())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/data/muon_data_test.py
+++ b/test/data/muon_data_test.py
@@ -1,4 +1,4 @@
-from MuonDataLib.data.muon_data import MuonData
+from MuonDataLib.data.muon_data import MuonData, MuonEventData
 import unittest
 import os
 from unittest import mock
@@ -62,3 +62,114 @@ class MuonDataTest(unittest.TestCase):
         detector_1.assert_called_once()
 
         os.remove('tmp.nxs')
+
+
+class MuonEventDataTest(unittest.TestCase):
+
+    def test_MuonEventData_init(self):
+        '''
+        Instead of creating the full objects we
+        will just use strings. Since we only need
+        to check that the dict matches the
+        argument correctly.
+        For simplicity the strings used match
+        the keys in the dict
+        '''
+        data = MuonEventData('events',
+                             'cache',
+                             'sample',
+                             'raw_data',
+                             'source',
+                             'user',
+                             'periods',
+                             'detector_1')
+
+        for key in data._dict.keys():
+            self.assertEqual(key, data._dict[key])
+        self.assertEqual(data._events, 'events')
+        self.assertEqual(data._cache, 'cache')
+
+    def test_save_histogram_empty_cache(self):
+        """
+        Want to test that all of the individual
+        parts are called when saving. So will use
+        mocks.
+        """
+
+        sample = fake_nxs_part()
+        raw_data = fake_nxs_part()
+        source = fake_nxs_part()
+        user = fake_nxs_part()
+        periods = fake_nxs_part()
+        detector_1 = fake_nxs_part()
+
+        events = mock.Mock()
+        events.histogram = mock.Mock()
+
+        cache = mock.Mock()
+        cache.empty = mock.Mock(return_value=True)
+
+        data = MuonEventData(events,
+                             cache,
+                             sample,
+                             raw_data,
+                             source,
+                             user,
+                             periods,
+                             detector_1)
+        data.save_histograms('tmp.nxs')
+
+        cache.empty.assert_called_once()
+        events.histogram.assert_called_once_with(cache=cache)
+        sample.assert_called_once()
+        raw_data.assert_called_once()
+        source.assert_called_once()
+        user.assert_called_once()
+        periods.assert_called_once()
+        detector_1.assert_called_once()
+
+        os.remove('tmp.nxs')
+
+    def test_save_histogram_occupied_cache(self):
+        """
+        Want to test that all of the individual
+        parts are called when saving. So will use
+        mocks.
+        """
+        sample = fake_nxs_part()
+        raw_data = fake_nxs_part()
+        source = fake_nxs_part()
+        user = fake_nxs_part()
+        periods = fake_nxs_part()
+        detector_1 = fake_nxs_part()
+
+        events = mock.Mock()
+        events.histogram = mock.Mock()
+
+        cache = mock.Mock()
+        cache.empty = mock.Mock(return_value=False)
+
+        data = MuonEventData(events,
+                             cache,
+                             sample,
+                             raw_data,
+                             source,
+                             user,
+                             periods,
+                             detector_1)
+        data.save_histograms('tmp.nxs')
+
+        cache.empty.assert_called_once()
+        events.histogram.assert_not_called()
+        sample.assert_called_once()
+        raw_data.assert_called_once()
+        source.assert_called_once()
+        user.assert_called_once()
+        periods.assert_called_once()
+        detector_1.assert_called_once()
+
+        os.remove('tmp.nxs')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/data/periods_test.py
+++ b/test/data/periods_test.py
@@ -23,7 +23,7 @@ class _PeriodsTest(PeriodsTestTemplate, TestHelper):
     def create_multiperiod_data(self):
         args = super().create_multiperiod_data()
         self.requested = args[3]
-        self.raw = np.asarray(args[4], dtype=np.double)
+        self.raw = args[4]
         self.counts = np.asarray(args[6], dtype=np.int32)
         return _Periods(args[0], args[1], args[2],
                         args[5], args[7])
@@ -33,7 +33,7 @@ class _PeriodsTest(PeriodsTestTemplate, TestHelper):
                          self.raw, self.counts)
 
     def setUp(self):
-        self.filename = '_periods.nxs'
+        self.filename = '_test_periods.nxs'
 
 
 class PeriodsTest(PeriodsTestTemplate, TestHelper):
@@ -47,7 +47,7 @@ class PeriodsTest(PeriodsTestTemplate, TestHelper):
         return Periods(*args)
 
     def setUp(self):
-        self.filename = 'periods.nxs'
+        self.filename = 'test_periods.nxs'
 
     def save(self, period, file):
         period.save_nxs2(file)
@@ -60,7 +60,7 @@ class PeriodsTest(PeriodsTestTemplate, TestHelper):
 
         self.assertArrays(self.period._dict['requested'], [500])
         self.assertArrays(self.period._dict['raw'], [1000])
-        self.assertArrays(self.period._dict['counts'], [1.23])
+        self.assertArrays(self.period._dict['counts'], [12])
 
     def test_periods_object_stores_correct_info_multiperiod(self):
         """
@@ -70,7 +70,7 @@ class PeriodsTest(PeriodsTestTemplate, TestHelper):
 
         self.assertArrays(self.period._dict['requested'], [500, 400])
         self.assertArrays(self.period._dict['raw'], [1000, 500])
-        self.assertArrays(self.period._dict['counts'], [1.23, 4.56])
+        self.assertArrays(self.period._dict['counts'], [12, 45])
 
 
 class EventsPeriodsTest(PeriodsTestTemplate, TestHelper):
@@ -82,7 +82,11 @@ class EventsPeriodsTest(PeriodsTestTemplate, TestHelper):
                                args[0], args[1],
                                args[2], args[5],
                                args[7])
-        cache.save(args[6], args[4], args[3])
+        cache.save(np.asarray([[[2, 3], [5, 2]]], dtype=np.int32),
+                   np.asarray([3.2, 5.6], dtype=np.double),
+                   np.asarray(args[4], dtype=np.int32))
+
+        cache.set_requested_frames(np.asarray(args[3], dtype=np.int32))
         return events
 
     def create_multiperiod_data(self):
@@ -92,40 +96,18 @@ class EventsPeriodsTest(PeriodsTestTemplate, TestHelper):
                                args[0], args[1],
                                args[2], args[5],
                                args[7])
-        cache.save(args[6], args[4], args[3])
+        cache.save(np.asarray([[[2, 3], [5, 2]],
+                               [[20, 21], [1, 3]]], dtype=np.int32),
+                   np.asarray([3.2, 5.6], dtype=np.double),
+                   np.asarray(args[4], dtype=np.int32))
+        cache.set_requested_frames(np.asarray(args[3], dtype=np.int32))
         return events
 
     def save(self, period, file):
         period.save_nxs2(file)
 
     def setUp(self):
-        self.filename = 'events_periods.nxs'
-
-    def test_periods_object_stores_correct_info_single_period(self):
-        """
-        Check the class stores data correctly
-        """
-        super().test_periods_object_stores_correct_info_single_period()
-
-        counts, bins = self.period._cache.get_histograms()
-        requested = self.period._cache.get_total_frames()
-
-        self.assertArrays(requested, [500])
-        self.assertArrays(bins, [1000])
-        self.assertArrays(counts, [1.23])
-
-    def test_periods_object_stores_correct_info_multiperiod(self):
-        """
-        Check the class stores data correctly
-        """
-        super().test_periods_object_stores_correct_info_multiperiod()
-
-        counts, bins = self.period._cache.get_histograms()
-        requested = self.period._cache.get_total_frames()
-
-        self.assertArrays(requested, [500, 400])
-        self.assertArrays(bins, [1000, 500])
-        self.assertArrays(counts, [1.23, 4.56])
+        self.filename = 'test_events_periods.nxs'
 
 
 if __name__ == '__main__':

--- a/test/data/periods_test.py
+++ b/test/data/periods_test.py
@@ -24,7 +24,7 @@ class _PeriodsTest(PeriodsTestTemplate, TestHelper):
         args = super().create_multiperiod_data()
         self.requested = args[3]
         self.raw = args[4]
-        self.counts = np.asarray(args[6], dtype=np.int32)
+        self.counts = np.asarray(args[6], dtype=np.double)
         return _Periods(args[0], args[1], args[2],
                         args[5], args[7])
 
@@ -60,7 +60,7 @@ class PeriodsTest(PeriodsTestTemplate, TestHelper):
 
         self.assertArrays(self.period._dict['requested'], [500])
         self.assertArrays(self.period._dict['raw'], [1000])
-        self.assertArrays(self.period._dict['counts'], [12])
+        self.assertArrays(self.period._dict['total_counts'], [1.2e-5])
 
     def test_periods_object_stores_correct_info_multiperiod(self):
         """
@@ -70,7 +70,7 @@ class PeriodsTest(PeriodsTestTemplate, TestHelper):
 
         self.assertArrays(self.period._dict['requested'], [500, 400])
         self.assertArrays(self.period._dict['raw'], [1000, 500])
-        self.assertArrays(self.period._dict['counts'], [12, 45])
+        self.assertArrays(self.period._dict['total_counts'], [1.2e-5, 4.5e-5])
 
 
 class EventsPeriodsTest(PeriodsTestTemplate, TestHelper):

--- a/test/data/periods_test.py
+++ b/test/data/periods_test.py
@@ -1,165 +1,131 @@
-from MuonDataLib.data.periods import (Periods,
-                                      read_periods_from_histogram)
+from MuonDataLib.data.periods import (_Periods,
+                                      Periods,
+                                      EventsPeriods)
 
 from MuonDataLib.test_helpers.unit_test import TestHelper
-import h5py
+from MuonDataLib.test_helpers.periods import PeriodsTestTemplate
+from MuonDataLib.cython_ext.events_cache import EventsCache
+
 import unittest
-import os
+import numpy as np
 
 
-FILENAME = 'periods_test.nxs'
+class _PeriodsTest(PeriodsTestTemplate, TestHelper):
+
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        self.requested = args[3]
+        self.raw = args[4]
+        self.counts = args[6]
+        return _Periods(args[0], args[1], args[2],
+                        args[5], args[7])
+
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        self.requested = args[3]
+        self.raw = np.asarray(args[4], dtype=np.double)
+        self.counts = np.asarray(args[6], dtype=np.int32)
+        return _Periods(args[0], args[1], args[2],
+                        args[5], args[7])
+
+    def save(self, period, file):
+        period.save_nxs2(file, self.requested,
+                         self.raw, self.counts)
+
+    def setUp(self):
+        self.filename = '_periods.nxs'
 
 
-def create_single_period_data():
-    return Periods(1, 'period 1', [1], [500], [1000], [1], [1.23], [2])
+class PeriodsTest(PeriodsTestTemplate, TestHelper):
 
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        return Periods(*args)
 
-def create_multiperiod_data():
-    return Periods(2, 'period 1; period 2', [1, 2], [500, 400],
-                   [1000, 500], [1, 0], [1.23, 4.56], [42, 42])
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        return Periods(*args)
 
+    def setUp(self):
+        self.filename = 'periods.nxs'
 
-class PeriodsTest(TestHelper):
+    def save(self, period, file):
+        period.save_nxs2(file)
 
     def test_periods_object_stores_correct_info_single_period(self):
         """
         Check the class stores data correctly
         """
-        period = create_single_period_data()
+        super().test_periods_object_stores_correct_info_single_period()
 
-        self.assertEqual(period._dict['number'], 1)
-        self.assertEqual(period._dict['labels'], 'period 1')
-        self.assertArrays(period._dict['type'], [1])
-        self.assertArrays(period._dict['requested'], [500])
-        self.assertArrays(period._dict['raw'], [1000])
-        self.assertArrays(period._dict['output'], [1])
-        self.assertArrays(period._dict['sequences'], [2])
-        self.assertArrays(period._dict['counts'], [1.23])
-
-    def test_periods_object_saves_correct_info_single_period(self):
-        """
-        Test that the class can save to a nexus file
-        correctly
-        """
-        periods = create_single_period_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            periods.save_nxs2(file)
-
-        with h5py.File(FILENAME, 'r') as file:
-            keys = self.compare_keys(file, ['raw_data_1'])
-            group = file[keys[0]]
-            keys = self.compare_keys(group, ['periods'])
-            group = group[keys[0]]
-            self.assertEqual(group.attrs['NX_class'], 'NXperiod')
-
-            self.assertEqual(group['number'][0], 1)
-            self.assertString(group, 'labels', 'period 1')
-            self.assertArrays(group['type'], [1])
-            self.assertArrays(group['frames_requested'], [500])
-            self.assertArrays(group['raw_frames'], [1000])
-            self.assertArrays(group['output'], [1])
-            self.assertArrays(group['sequences'], [2])
-            self.assertArrays(group['total_counts'], [1.23])
-
-        os.remove(FILENAME)
-
-    def test_load_periods_gets_correct_info_single_period(self):
-        """
-        Check load method gets the correct information.
-        The above tests prove that the information
-        stored is correct and that it is correctly
-        written to file.
-        """
-        period = create_single_period_data()
-
-        with h5py.File(FILENAME, 'w') as file:
-            period.save_nxs2(file)
-        del period
-
-        with h5py.File(FILENAME, 'r') as file:
-            load_period = read_periods_from_histogram(file)
-
-        self.assertEqual(load_period._dict['number'], 1)
-        self.assertEqual(load_period._dict['labels'], 'period 1')
-        self.assertArrays(load_period._dict['type'], [1])
-        self.assertArrays(load_period._dict['requested'], [500])
-        self.assertArrays(load_period._dict['raw'], [1000])
-        self.assertArrays(load_period._dict['output'], [1])
-        self.assertArrays(load_period._dict['sequences'], [2])
-        self.assertArrays(load_period._dict['counts'], [1.23])
-
-        os.remove(FILENAME)
+        self.assertArrays(self.period._dict['requested'], [500])
+        self.assertArrays(self.period._dict['raw'], [1000])
+        self.assertArrays(self.period._dict['counts'], [1.23])
 
     def test_periods_object_stores_correct_info_multiperiod(self):
         """
         Check the class stores data correctly
         """
-        period = create_multiperiod_data()
+        super().test_periods_object_stores_correct_info_multiperiod()
 
-        self.assertEqual(period._dict['number'], 2)
-        self.assertEqual(period._dict['labels'], 'period 1; period 2')
-        self.assertArrays(period._dict['type'], [1, 2])
-        self.assertArrays(period._dict['requested'], [500, 400])
-        self.assertArrays(period._dict['raw'], [1000, 500])
-        self.assertArrays(period._dict['output'], [1, 0])
-        self.assertArrays(period._dict['sequences'], [42, 42])
-        self.assertArrays(period._dict['counts'], [1.23, 4.56])
+        self.assertArrays(self.period._dict['requested'], [500, 400])
+        self.assertArrays(self.period._dict['raw'], [1000, 500])
+        self.assertArrays(self.period._dict['counts'], [1.23, 4.56])
 
-    def test_periods_object_saves_correct_info_multiperiod(self):
+
+class EventsPeriodsTest(PeriodsTestTemplate, TestHelper):
+
+    def create_single_period_data(self):
+        args = super().create_single_period_data()
+        cache = EventsCache()
+        events = EventsPeriods(cache,
+                               args[0], args[1],
+                               args[2], args[5],
+                               args[7])
+        cache.save(args[6], args[4], args[3])
+        return events
+
+    def create_multiperiod_data(self):
+        args = super().create_multiperiod_data()
+        cache = EventsCache()
+        events = EventsPeriods(cache,
+                               args[0], args[1],
+                               args[2], args[5],
+                               args[7])
+        cache.save(args[6], args[4], args[3])
+        return events
+
+    def save(self, period, file):
+        period.save_nxs2(file)
+
+    def setUp(self):
+        self.filename = 'events_periods.nxs'
+
+    def test_periods_object_stores_correct_info_single_period(self):
         """
-        Test that the class can save to a nexus file
-        correctly
+        Check the class stores data correctly
         """
-        period = create_multiperiod_data()
+        super().test_periods_object_stores_correct_info_single_period()
 
-        with h5py.File(FILENAME, 'w') as file:
-            period.save_nxs2(file)
+        counts, bins = self.period._cache.get_histograms()
+        requested = self.period._cache.get_total_frames()
 
-        with h5py.File(FILENAME, 'r') as file:
-            keys = self.compare_keys(file, ['raw_data_1'])
-            group = file[keys[0]]
-            keys = self.compare_keys(group, ['periods'])
-            group = group[keys[0]]
-            self.assertEqual(group.attrs['NX_class'], 'NXperiod')
+        self.assertArrays(requested, [500])
+        self.assertArrays(bins, [1000])
+        self.assertArrays(counts, [1.23])
 
-            self.assertEqual(group['number'][0], 2)
-            self.assertEqual(group['labels'][0].decode(), 'period 1; period 2')
-            self.assertArrays(group['type'], [1, 2])
-            self.assertArrays(group['frames_requested'], [500, 400])
-            self.assertArrays(group['raw_frames'], [1000, 500])
-            self.assertArrays(group['output'], [1, 0])
-            self.assertArrays(group['sequences'], [42, 42])
-            self.assertArrays(group['total_counts'], [1.23, 4.56])
-
-        os.remove(FILENAME)
-
-    def test_load_detector1_gets_correct_info_multiperiod(self):
+    def test_periods_object_stores_correct_info_multiperiod(self):
         """
-        Check load method gets the correct information.
-        The above tests prove that the information
-        stored is correct and that it is correctly
-        written to file.
+        Check the class stores data correctly
         """
-        period = create_multiperiod_data()
+        super().test_periods_object_stores_correct_info_multiperiod()
 
-        with h5py.File(FILENAME, 'w') as file:
-            period.save_nxs2(file)
-        del period
+        counts, bins = self.period._cache.get_histograms()
+        requested = self.period._cache.get_total_frames()
 
-        with h5py.File(FILENAME, 'r') as file:
-            load_period = read_periods_from_histogram(file)
-
-        self.assertEqual(load_period._dict['number'], 2)
-        self.assertEqual(load_period._dict['labels'], 'period 1; period 2')
-        self.assertArrays(load_period._dict['type'], [1, 2])
-        self.assertArrays(load_period._dict['requested'], [500, 400])
-        self.assertArrays(load_period._dict['raw'], [1000, 500])
-        self.assertArrays(load_period._dict['output'], [1, 0])
-        self.assertArrays(load_period._dict['sequences'], [42, 42])
-        self.assertArrays(load_period._dict['counts'], [1.23, 4.56])
-
-        os.remove(FILENAME)
+        self.assertArrays(requested, [500, 400])
+        self.assertArrays(bins, [1000, 500])
+        self.assertArrays(counts, [1.23, 4.56])
 
 
 if __name__ == '__main__':

--- a/test/data/raw_data_test.py
+++ b/test/data/raw_data_test.py
@@ -66,8 +66,8 @@ class EventsRawDataTest(RawDataTestTemplate, TestHelper):
                             args[10], args[11])
         counts = np.asarray([[[1]]], dtype=np.int32)
         bins = np.asarray([1, 2], dtype=np.double)
-        cache.save(counts, bins, np.asarray([args[8]]))
-        cache.set_good_frames(np.asarray([args[0]]))
+        cache.save(counts, bins, np.asarray([args[8]], dtype=np.int32))
+        cache.set_good_frames(np.asarray([args[0]], dtype=np.int32))
         return raw, args[9], args[10]
 
     def save(self, raw, file):

--- a/test/data/raw_data_test.py
+++ b/test/data/raw_data_test.py
@@ -66,8 +66,8 @@ class EventsRawDataTest(RawDataTestTemplate, TestHelper):
                             args[10], args[11])
         counts = np.asarray([[[1]]], dtype=np.int32)
         bins = np.asarray([1, 2], dtype=np.double)
-        cache.save(counts, bins, args[8])
-        cache.set_good_frames(args[0])
+        cache.save(counts, bins, np.asarray([args[8]]))
+        cache.set_good_frames(np.asarray([args[0]]))
         return raw, args[9], args[10]
 
     def save(self, raw, file):
@@ -82,8 +82,10 @@ class EventsRawDataTest(RawDataTestTemplate, TestHelper):
         """
         super().test_raw_data_object_stores_correct_info()
 
-        self.assertEqual(self.raw._cache.get_good_frames(), 10)
-        self.assertEqual(self.raw._cache.get_total_frames(), 51)
+        good = np.asarray(self.raw._cache.get_good_frames())
+        self.assertEqual(good, 10)
+        total = np.asarray(self.raw._cache.get_total_frames())
+        self.assertEqual(total, 51)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Please use a descriptive name for the PR.
It will be used for the automated release notes along with the labels.
The labels that are used are:
 - ignore-for-release-notes
 - Data Loader
 - Maintenance
 - New Feature
 - bug
-->

### Description of work
This adds the code needed to allow for some of the new muon event nexus files to be loaded and converted into a muon nexus histogram file that Wimda can read. 

#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->
I have abstracted and added some of the classes for the nexus file properties (e.g. raw_data). This reduces the duplication of code. 

I have also created a cache that allows event information to be easily shared between nexus file properties. The cache is limited to data that is relevant for nexus file properties. i.e. stores histograms instead of events. 


<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

Fixes #14 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx. One line per issue fixed. -->
<!-- alternative
*There is no associated issue.*
-->

### To test:

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Warning: If the cython code crashes no feedback is provided. This is because the error checking has been turned off to increase the speed. A work around is shown below. 

```
from MuonDataLib.data.loader.load_events import load_events
import os

file_name = 'HIFIRun0.nxs'
file = os.path.join(os.path.dirname(__file__),
                        '..',
                        file_name)

data = load_events(file, 64)
print('start')

output = 'HIFI0.nxs'

data.save_histograms(Output)
print('end')

```

If it works it save the file and then print the message "end". If you don't get the end message then it has crashed. 

This doesn't work for the simulated data that I have as it is missing some metadata. It should work on stuff coming from the beamline. 

#### Code Review

- Is the code of an acceptable quality?
- Are the unit tests small and test the class in isolation?
- Does the documentation build [ReadTheDocs](https://readthedocs.org/projects/muondatalib/builds/)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.

