### PR TITLE
Tmp amp filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ where = ["src"]
 [project]
 name = 'muondatalib'
 
-version = "0.12.0b0"
+version = "0.13.0b0"
 
 requires-python = ">=3.8"
 dependencies = ['numpy', 'h5py', 'plotly', 'cython', 'pyside6', 'dash[testing]', 'dash_daq', 'dash-ag-grid', 'dash_bootstrap_components']

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup, Extension
 import numpy
 
 
-version = "0.12.0b0"
+version = "0.13.0b0"
 
 
 PACKAGE_NAME = 'MuonDataLib'

--- a/src/MuonDataLib/GUI/amp/presenter.py
+++ b/src/MuonDataLib/GUI/amp/presenter.py
@@ -1,0 +1,28 @@
+from MuonDataLib.GUI.table.presenter import PresenterTemplate
+from MuonDataLib.GUI.amp.view import AmplitudeView
+from MuonDataLib.GUI.plot_area.presenter import PlotAreaPresenter
+import numpy as np
+
+
+class AmpPresenter(PresenterTemplate):
+    """
+    A class for the view of the sample log filter
+    widget. This follows the MVP
+    pattern.
+    """
+    def __init__(self):
+        """
+        This creates the presenter object for the
+        widget.
+        """
+
+        # create a plot area
+        self._plot = PlotAreaPresenter('amp')
+        self._view = AmplitudeView(self)
+
+    def plot(self, data):
+        hist, bins = data.get_peak_property_histogram('Amplitudes')
+        return self._plot.plot(['amplitudes'],
+                               [(bins[:-1] + bins[1:])/2.],
+                               [hist],
+                               'Amplitude')

--- a/src/MuonDataLib/GUI/amp/presenter.py
+++ b/src/MuonDataLib/GUI/amp/presenter.py
@@ -23,7 +23,7 @@ class AmpPresenter(PresenterTemplate):
         """
         Loads the amplitude data from
         a json file.
-        :para data: the dict containing the
+        :param data: the dict containing the
         amplitude
         :returns: the amplitude filter details
         """
@@ -31,7 +31,7 @@ class AmpPresenter(PresenterTemplate):
 
     def plot(self, data):
         """
-        Creates a plot of the amplitude height and counts. ]
+        Creates a plot of the amplitude height and counts.
         :param data: the MuonData object, with an amlitude filter
         :returns: the graph object for histogram
         """

--- a/src/MuonDataLib/GUI/amp/presenter.py
+++ b/src/MuonDataLib/GUI/amp/presenter.py
@@ -5,8 +5,8 @@ from MuonDataLib.GUI.plot_area.presenter import PlotAreaPresenter
 
 class AmpPresenter(PresenterTemplate):
     """
-    A class for the view of the sample log filter
-    widget. This follows the MVP
+    A class for the presenter of the Amplitude
+    filter widget. This follows the MVP
     pattern.
     """
     def __init__(self):
@@ -20,9 +20,21 @@ class AmpPresenter(PresenterTemplate):
         self._view = AmplitudeView(self)
 
     def load(self, data):
+        """
+        Loads the amplitude data from
+        a json file.
+        :para data: the dict containing the
+        amplitude
+        :returns: the amplitude filter details
+        """
         return data['Amplitudes']
 
     def plot(self, data):
+        """
+        Creates a plot of the amplitude height and counts. ]
+        :param data: the MuonData object, with an amlitude filter
+        :returns: the graph object for histogram
+        """
         hist, bins = data.get_peak_property_histogram('Amplitudes')
         return self._plot.plot(['Counts'],
                                [(bins[:-1] + bins[1:])/2.],

--- a/src/MuonDataLib/GUI/amp/presenter.py
+++ b/src/MuonDataLib/GUI/amp/presenter.py
@@ -1,7 +1,6 @@
 from MuonDataLib.GUI.table.presenter import PresenterTemplate
 from MuonDataLib.GUI.amp.view import AmplitudeView
 from MuonDataLib.GUI.plot_area.presenter import PlotAreaPresenter
-import numpy as np
 
 
 class AmpPresenter(PresenterTemplate):
@@ -20,9 +19,12 @@ class AmpPresenter(PresenterTemplate):
         self._plot = PlotAreaPresenter('amp')
         self._view = AmplitudeView(self)
 
+    def load(self, data):
+        return data['Amplitudes']
+
     def plot(self, data):
         hist, bins = data.get_peak_property_histogram('Amplitudes')
-        return self._plot.plot(['amplitudes'],
+        return self._plot.plot(['Counts'],
                                [(bins[:-1] + bins[1:])/2.],
                                [hist],
                                'Amplitude')

--- a/src/MuonDataLib/GUI/amp/view.py
+++ b/src/MuonDataLib/GUI/amp/view.py
@@ -1,0 +1,43 @@
+from MuonDataLib.GUI.view_template import ViewTemplate
+from dash import html, dcc
+from dash import Input, Output, State, callback
+import dash_bootstrap_components as dbc
+
+
+class AmplitudeView(ViewTemplate):
+    """
+    A class for the view of the filter
+    widget. This follows the MVP
+    pattern.
+    """
+    def generate(self, presenter):
+        """
+        Creates the filter widget's GUI.
+        :returns: the layout of the widget's
+        GUI.
+        """
+        return html.Div([
+            presenter._plot.layout,
+            html.Div(['Amplitude threshold', dcc.Input(id='Amp', value=0, type='numeric')])
+            ])
+
+    def set_callbacks(self, presenter):
+        """
+        Sets the callbacks for the GUI.
+        Have additional callbacks for:
+        - updating the data in the pop up
+        - closing the pop up
+        - setting the combo box options and value when
+        opening the pop up
+        :param presenter: the presenter object
+        """
+        super().set_callbacks(presenter)
+
+        #callback([Output('log_plot', 'figure', allow_duplicate=True),
+        #          Output('log_max', 'children'),
+        #          Output('log_mean', 'children'),
+        #          Output('log_min', 'children'),
+        #          Output('log_std', 'children'),],
+        #         Input('log_selection', 'value'),
+        #         prevent_initial_call=True)(presenter.show_log_data)
+

--- a/src/MuonDataLib/GUI/amp/view.py
+++ b/src/MuonDataLib/GUI/amp/view.py
@@ -1,43 +1,30 @@
 from MuonDataLib.GUI.view_template import ViewTemplate
 from dash import html, dcc
-from dash import Input, Output, State, callback
-import dash_bootstrap_components as dbc
 
 
 class AmplitudeView(ViewTemplate):
     """
-    A class for the view of the filter
+    A class for the view of the amplitude
     widget. This follows the MVP
     pattern.
     """
     def generate(self, presenter):
         """
-        Creates the filter widget's GUI.
+        Creates the amplitude widget's GUI.
         :returns: the layout of the widget's
         GUI.
         """
         return html.Div([
             presenter._plot.layout,
-            html.Div(['Amplitude threshold', dcc.Input(id='Amp', value=0, type='numeric')])
+            html.Div(['Amplitude threshold',
+                      dcc.Input(id='Amp',
+                                value=0,
+                                type='numeric')])
             ])
 
     def set_callbacks(self, presenter):
         """
         Sets the callbacks for the GUI.
-        Have additional callbacks for:
-        - updating the data in the pop up
-        - closing the pop up
-        - setting the combo box options and value when
-        opening the pop up
         :param presenter: the presenter object
         """
         super().set_callbacks(presenter)
-
-        #callback([Output('log_plot', 'figure', allow_duplicate=True),
-        #          Output('log_max', 'children'),
-        #          Output('log_mean', 'children'),
-        #          Output('log_min', 'children'),
-        #          Output('log_std', 'children'),],
-        #         Input('log_selection', 'value'),
-        #         prevent_initial_call=True)(presenter.show_log_data)
-

--- a/src/MuonDataLib/GUI/control_pane/presenter.py
+++ b/src/MuonDataLib/GUI/control_pane/presenter.py
@@ -54,7 +54,7 @@ class ControlPanePresenter(PresenterTemplate):
         name = self._filter._log.get_new_log_name([])
         return self._plot.new_plot([name], self._filter._log._logs)
 
-    def make_plot(self, time_data, log_data, state):
+    def make_plot(self, time_data, log_data, amp_data, state):
         """
         This method creates a plot.
         If no sample logs are selected, it will just plot a
@@ -75,7 +75,8 @@ class ControlPanePresenter(PresenterTemplate):
         self._plot.new_plot(names, self._filter._log._logs)
         start, stop, msg = self._filter.update_filters(time_data,
                                                        state,
-                                                       log_data)
+                                                       log_data,
+                                                       amp_data)
 
         self.add_filters(start, stop, log_data)
 
@@ -306,5 +307,5 @@ class ControlPanePresenter(PresenterTemplate):
         """
         with open(name, 'r') as file:
             data = json.load(file)
-        time_data, log_data, state, cols = self._filter.load(data)
-        return time_data, log_data, state, cols
+        time_data, log_data, amp, state, cols = self._filter.load(data)
+        return time_data, log_data, amp, state, cols

--- a/src/MuonDataLib/GUI/control_pane/presenter.py
+++ b/src/MuonDataLib/GUI/control_pane/presenter.py
@@ -62,6 +62,7 @@ class ControlPanePresenter(PresenterTemplate):
         for the data that is kept.
         :param time_data: the data from the time filter table
         :param log_data: the data from the sample log filter table.
+        :param amp_data: the amplitudes from the sample log filter table.
         Its also used to get which plots to make.
         :param state: the state of the time filters (inc/exc)
         :returns: an updated figure
@@ -301,8 +302,8 @@ class ControlPanePresenter(PresenterTemplate):
         A method to get the filters from a file
         and populate the GUI.
         :param name: the name of the json file
-        :returns: the time table data, the log table data,
-        and the state for the time filter (include/exclude)
+        :returns: the time table data, the log table data, time filter,
+        amplitude filter, the state for the time filter (include/exclude)
         and the column headers
         """
         with open(name, 'r') as file:

--- a/src/MuonDataLib/GUI/control_pane/view.py
+++ b/src/MuonDataLib/GUI/control_pane/view.py
@@ -34,7 +34,8 @@ class ControlPaneView(ViewTemplate):
         callback(Output('main_plot', 'figure', allow_duplicate=True),
                  [Input('time-table', 'rowData'),
                   Input('log-table', 'rowData')],
-                 [State('dropdown-time', 'value')],
+                 [State('Amp', 'value'),
+                  State('dropdown-time', 'value')],
                  prevent_initial_call=True)(presenter.make_plot)
 
         callback([Output('main_tooltip', 'show', allow_duplicate=True),

--- a/src/MuonDataLib/GUI/filters/presenter.py
+++ b/src/MuonDataLib/GUI/filters/presenter.py
@@ -39,7 +39,7 @@ class FilterPresenter(PresenterTemplate):
         :param log_data: the log data for the
         log filter table
         :param amp_data: The amplitude filter data
-        :returns: if the  the name in the GUI
+        :returns: if to hide the name in the GUI
         """
         if (self._time_file_data == time_data and
                 self._log_file_data == log_data and

--- a/src/MuonDataLib/GUI/filters/presenter.py
+++ b/src/MuonDataLib/GUI/filters/presenter.py
@@ -24,8 +24,9 @@ class FilterPresenter(PresenterTemplate):
         self._data = None
         self._time_file_data = []
         self._log_file_data = []
+        self._amp_file_data = 0
 
-    def show_file(self, name, time_data, log_data):
+    def show_file(self, name, time_data, log_data, amp_data):
         """
         If to display the name of the loaded
         filter file. This method chekcs
@@ -40,7 +41,8 @@ class FilterPresenter(PresenterTemplate):
         :returns: if to show the name in the GUI
         """
         if (self._time_file_data == time_data and
-                self._log_file_data == log_data):
+                self._log_file_data == log_data and
+                self._amp_file_data == float(amp_data)):
             return False
         return True
 
@@ -63,7 +65,7 @@ class FilterPresenter(PresenterTemplate):
 
         self._time.set_time_range(times[0], times[-1] + 32e-6)
 
-    def apply_filters(self, time_filters, state, log_filters):
+    def apply_filters(self, time_filters, state, log_filters, amp_filters):
         """
         A method to apply the filters to the
         muon event data object. This allows
@@ -72,8 +74,11 @@ class FilterPresenter(PresenterTemplate):
         :param time_filters: A list of filters (dicts)
         :param state: If to include or exclude the data
         :param log_filters: a list of log filters
+        :param amp_filters: amplitude filter
         """
-        if len(time_filters) == 0 and len(log_filters) == 0:
+        if (len(time_filters) == 0 and
+                len(log_filters) == 0 and
+                amp_filters == 0):
             # if no filters, do nothing
             return
 
@@ -109,8 +114,10 @@ class FilterPresenter(PresenterTemplate):
             elif filter_type == 'below':
                 self._data.keep_data_sample_log_below(sample_log,
                                                       stop)
+        self._data.keep_data_peak_property_above("Amplitudes",
+                                                 float(amp_filters))
 
-    def update_filters(self, time_filters, state, log_filters):
+    def update_filters(self, time_filters, state, log_filters, amp_filters):
         """
         Gets the updated start and stop times for the
         exclude filters. The first step is a bit
@@ -131,7 +138,7 @@ class FilterPresenter(PresenterTemplate):
         if len(time_filters) == 0 and len(log_filters) == 0:
             return [], [], ''
         try:
-            self.apply_filters(time_filters, state, log_filters)
+            self.apply_filters(time_filters, state, log_filters, amp_filters)
         except RuntimeError as msg:
             return [], [], str(msg)
         start, stop = self._data.get_filters_as_times()
@@ -184,7 +191,8 @@ class FilterPresenter(PresenterTemplate):
 
         return row_log['y_min_log-table'], row_log['y_max_log-table']
 
-    def calculate(self, n_clicks, time_filters, state, log_filters):
+    def calculate(self, n_clicks, time_filters, state,
+                  log_filters, amp_filter):
         """
         A method to calculate the number of
         events that would be used to make
@@ -201,7 +209,7 @@ class FilterPresenter(PresenterTemplate):
         of events, the error message (if there is one)
         """
         try:
-            self.apply_filters(time_filters, state, log_filters)
+            self.apply_filters(time_filters, state, log_filters, amp_filter)
         except RuntimeError as msg:
             return self._view.get_N(0), str(msg)
         _ = self._data.histogram()
@@ -222,8 +230,11 @@ class FilterPresenter(PresenterTemplate):
 
         log_data = self._log.load(filters['sample_log_filters'])
         self._log_file_data = log_data
-        print('loading....#', time_data, log_data)
-        return time_data, log_data, state, self.headers
+
+        self._amp_file_data = self._amp.load(filters['peak_property'])
+
+        print('loading filters ....')
+        return time_data, log_data, self._amp_file_data, state, self.headers
 
     def update_N_events(self, update, current_str):
         """

--- a/src/MuonDataLib/GUI/filters/presenter.py
+++ b/src/MuonDataLib/GUI/filters/presenter.py
@@ -38,7 +38,8 @@ class FilterPresenter(PresenterTemplate):
         time filter table
         :param log_data: the log data for the
         log filter table
-        :returns: if to show the name in the GUI
+        :param amp_data: The amplitude filter data
+        :returns: if the  the name in the GUI
         """
         if (self._time_file_data == time_data and
                 self._log_file_data == log_data and
@@ -130,6 +131,7 @@ class FilterPresenter(PresenterTemplate):
         for the time filter table
         :param log_filters: the data from the sample
         log filter table
+        :param apm_filters: the amplitude filter
         :returns: a list of the exclude filter start times,
         a list of the exclude filter end times,
         an error message.
@@ -205,9 +207,11 @@ class FilterPresenter(PresenterTemplate):
         data.
         :param log_filters: the data from the
         sample log filter table
+        :param amp_filter: the amplitude filter
         :returns: The string to display the number
         of events, the error message (if there is one)
         """
+        self._data.clear_filters()
         try:
             self.apply_filters(time_filters, state, log_filters, amp_filter)
         except RuntimeError as msg:
@@ -221,8 +225,8 @@ class FilterPresenter(PresenterTemplate):
         Loads the filters that have been reported from a json file
         :param filters: the dict of the filters
         :returns: the time filters, the sample log
-        filters and if to include/exclude the time filters,
-        the time filter table headers
+        filters, the amplitude filters, if to include/exclude the time filters,
+        and the table headers
         """
         time_data, state = self._time.load(filters['time_filters'])
         self._time_file_data = time_data

--- a/src/MuonDataLib/GUI/filters/presenter.py
+++ b/src/MuonDataLib/GUI/filters/presenter.py
@@ -1,6 +1,7 @@
 from MuonDataLib.GUI.presenter_template import PresenterTemplate
 from MuonDataLib.GUI.time.presenter import TimePresenter
 from MuonDataLib.GUI.log.presenter import LogPresenter
+from MuonDataLib.GUI.amp.presenter import AmpPresenter
 from MuonDataLib.GUI.filters.view import FilterView
 
 
@@ -18,6 +19,7 @@ class FilterPresenter(PresenterTemplate):
         """
         self._time = TimePresenter()
         self._log = LogPresenter()
+        self._amp = AmpPresenter()
         self._view = FilterView(self)
         self._data = None
         self._time_file_data = []

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -32,6 +32,9 @@ class FilterView(ViewTemplate):
                 dbc.AccordionItem(
                     [presenter._log.layout],
                     title="Sample Log filters"),
+                dbc.AccordionItem(
+                    [presenter._amp.layout],
+                    title="Amplitude filter"),
                 ],
                          start_collapsed=True),
             dbc.Button('Calculate',

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -54,13 +54,15 @@ class FilterView(ViewTemplate):
                  Input('calc_btn', 'n_clicks'),
                  [State('time-table', 'rowData'),
                   State('dropdown-time', 'value'),
-                  State('log-table', 'rowData')],
+                  State('log-table', 'rowData'),
+                  State('Amp', 'value')],
                  prevent_initial_call=True)(presenter.calculate)
 
         callback(Output('title_test', 'hidden'),
                  [Input('title_test', 'children'),
                   Input('time-table', 'rowData'),
                   Input('log-table', 'rowData'),
+                  Input('Amp', 'value'),
                   ],
                  prevent_initial_call=True)(presenter.show_file)
 

--- a/src/MuonDataLib/GUI/main_app/presenter.py
+++ b/src/MuonDataLib/GUI/main_app/presenter.py
@@ -175,6 +175,9 @@ class MainAppPresenter(object):
         """
         return self.control.plot_default()
 
+    def plot_amps(self, data):
+        return self.control._filter._amp.plot(data)
+
     def load_nxs(self, name, data, debug_state):
         """
         Loads a muon event nexus file.
@@ -192,7 +195,7 @@ class MainAppPresenter(object):
         """
         if name == self.load.file:
             return (self.control._plot.fig, data, True, True,
-                    self.control.headers, '')
+                    self.control.headers, {}, '')
         self.load.set_file(name)
 
         if 'None' in name:
@@ -202,6 +205,7 @@ class MainAppPresenter(object):
                     [],
                     True,
                     self.control.headers,
+                    {},
                     '')
         try:
             if debug_state:
@@ -217,10 +221,11 @@ class MainAppPresenter(object):
                     [],
                     True,
                     self.control.headers,
+                    {},
                     f'An error occurred: {err}')
 
         data = self.load.get_data
         self.control.set_data(data)
 
         return (self.plot(), [], False, [], False,
-                self.control.headers, '')
+                self.control.headers, self.plot_amps(data), '')

--- a/src/MuonDataLib/GUI/main_app/presenter.py
+++ b/src/MuonDataLib/GUI/main_app/presenter.py
@@ -93,11 +93,11 @@ class MainAppPresenter(object):
 
             filters = name[len(CURRENT):]
             result = self.control.read_filter(filters)
-            time_data, log_data, state, cols = result
-            return time_data, log_data, state, cols, ''
+            time_data, log_data, amp, state, cols = result
+            return time_data, log_data, amp, state, cols, ''
         except Exception as err:
             cols = self.control.headers
-            return [], [], 'Exclude', cols, f'Load filter error: {err}'
+            return [], [], 0, 'Exclude', cols, f'Load filter error: {err}'
 
     def alert(self, text):
         """
@@ -111,7 +111,8 @@ class MainAppPresenter(object):
             return False
         return True
 
-    def save_data(self, name, time_filters, time_mode, log_filters, debug):
+    def save_data(self, name, time_filters, time_mode,
+                  log_filters, amp_filters, debug):
         """
         Saves either a muon histogram nexus file
         or a filter file, from the current muon
@@ -139,7 +140,8 @@ class MainAppPresenter(object):
             print("saving to ", file)
             self.control._filter.apply_filters(time_filters,
                                                time_mode,
-                                               log_filters)
+                                               log_filters,
+                                               amp_filters)
             if dtype == "n":
                 data.save_histograms(file)
             elif dtype == 'j':

--- a/src/MuonDataLib/GUI/main_app/presenter.py
+++ b/src/MuonDataLib/GUI/main_app/presenter.py
@@ -83,6 +83,7 @@ class MainAppPresenter(object):
         :param debug: If debug mode is on or off
         :returns: The list of rows for the time filter table,
         the list of rows for the sample log filter table,
+        the amplitude filter,
         the state of the time filters (include/exclude),
         the column headers
         and an error message (if it fails)
@@ -124,6 +125,7 @@ class MainAppPresenter(object):
         or exclude the data
         :param log_filters: the data from the sample log
         filter table
+        :param amp_filters: the amplitude filters
         :param debug: if debug mode is on or off.
         :returns: the name of the saved file and
         the alert message
@@ -178,9 +180,15 @@ class MainAppPresenter(object):
         return self.control.plot_default()
 
     def plot_amps(self, data):
+        """
+        Simple method to plot the amplitude
+        histogram
+        :param data: the amplitude filter data
+        :returns: the plot object
+        """
         return self.control._filter._amp.plot(data)
 
-    def load_nxs(self, name, data, debug_state):
+    def load_nxs(self, name, data, amp, debug_state):
         """
         Loads a muon event nexus file.
         :param name: the 'CURRENT' text string and
@@ -193,11 +201,12 @@ class MainAppPresenter(object):
         - if the time filter table is disabled
         - if the sample log table is disabled
         - the filter table column names
+        - the amplitude filter
         - the alert message
         """
         if name == self.load.file:
             return (self.control._plot.fig, data, True, True,
-                    self.control.headers, {}, '')
+                    self.control.headers, amp '')
         self.load.set_file(name)
 
         if 'None' in name:

--- a/src/MuonDataLib/GUI/main_app/presenter.py
+++ b/src/MuonDataLib/GUI/main_app/presenter.py
@@ -204,7 +204,7 @@ class MainAppPresenter(object):
         - the sample log table data
         - if the sample log table is disabled
         - the filter table column names
-        - the amplitude filter
+        - plot of the amplitude histogram
         - the alert message
         """
         if name == self.load.file:
@@ -212,7 +212,9 @@ class MainAppPresenter(object):
             return (self.control._plot.fig,
                     time_data, False,
                     log_data, False,
-                    self.control.headers, '')
+                    self.control.headers,
+                    self.control._filter._amp._plot.fig,
+                    '')
         self.load.set_file(name)
 
         if 'None' in name:

--- a/src/MuonDataLib/GUI/main_app/view.py
+++ b/src/MuonDataLib/GUI/main_app/view.py
@@ -107,6 +107,7 @@ class MainApp(Dash):
         callback([
                   Output('time-table', 'rowData', allow_duplicate=True),
                   Output('log-table', 'rowData', allow_duplicate=True),
+                  Output('Amp', 'value', allow_duplicate=True),
                   Output('dropdown-time', 'value', allow_duplicate=True),
                   Output('time-table', 'columnDefs', allow_duplicate=True),
                   Output('error_msg', 'children', allow_duplicate=True)],
@@ -139,6 +140,7 @@ class MainApp(Dash):
                  [State('time-table', 'rowData'),
                   State('dropdown-time', 'values'),
                   State('log-table', 'rowData'),
+                  State('Amp', 'value'),
                   State('debug', 'on')],
                  prevent_initial_call=True)(self.presenter.save_data)
 

--- a/src/MuonDataLib/GUI/main_app/view.py
+++ b/src/MuonDataLib/GUI/main_app/view.py
@@ -121,6 +121,7 @@ class MainApp(Dash):
                   Output('log-table', 'rowData', allow_duplicate=True),
                   Output('log-table_add', 'disabled'),
                   Output('time-table', 'columnDefs', allow_duplicate=True),
+                  Output('amp_plot', 'figure'),
                   Output('error_msg', 'children', allow_duplicate=True)],
                  Input('file_name', 'children'),
                  [State('time-table', 'rowData'),

--- a/test/GUI/control_pane/control_pane_presenter_test.py
+++ b/test/GUI/control_pane/control_pane_presenter_test.py
@@ -59,7 +59,7 @@ class ControlPanePresenterTest(TestHelper):
                            'y_min' + LT: 0.4,
                            'y_max' + LT: 1}]
 
-        self.presenter.make_plot([], self.log_table, 'Exclude')
+        self.presenter.make_plot([], self.log_table, 0, 'Exclude')
 
     @property
     def get_fig(self):
@@ -117,7 +117,7 @@ class ControlPanePresenterTest(TestHelper):
         self.presenter._filter.update_filters = mock.Mock()
         self.presenter.clear()
 
-        self.presenter.make_plot([], [], 'Exclude')
+        self.presenter.make_plot([], [], 0, 'Exclude')
         self.presenter.add_filters.assert_not_called()
 
         self.assertMockOnce(self.presenter._plot.plot,
@@ -135,7 +135,7 @@ class ControlPanePresenterTest(TestHelper):
         self.presenter._filter.update_filters = mock.Mock(return_value=([],
                                                                         [],
                                                                         ''))
-        self.presenter.make_plot([], [], 'Exclude')
+        self.presenter.make_plot([], [], 0, 'Exclude')
 
         self.presenter._plot.new_plot.assert_called_once_with(['Temp'],
                                                               self.logs)
@@ -153,14 +153,15 @@ class ControlPanePresenterTest(TestHelper):
                                                       ''))
         self.presenter._filter.update_filters = mock_update_filters
 
-        self.presenter.make_plot([], [self.log_table[0]], 'Exclude')
+        self.presenter.make_plot([], [self.log_table[0]], 0, 'Exclude')
 
         self.presenter._plot.new_plot.assert_called_once_with(['Temp'],
                                                               self.logs)
 
         mock_update_filters.assert_called_once_with([],
                                                     'Exclude',
-                                                    [self.log_table[0]])
+                                                    [self.log_table[0]],
+                                                    0)
         self.presenter.add_filters.assert_called_once_with([],
                                                            'log',
                                                            [self.log_table[0]])
@@ -176,7 +177,7 @@ class ControlPanePresenterTest(TestHelper):
 
         self.presenter._filter.update_filters = mock_update_filters
 
-        self.presenter.make_plot([], self.log_table, 'Exclude')
+        self.presenter.make_plot([], self.log_table, 0, 'Exclude')
 
         self.presenter._plot.new_plot.assert_called_once_with(['Temp', 'B'],
                                                               self.logs)
@@ -185,7 +186,8 @@ class ControlPanePresenterTest(TestHelper):
                                                            self.log_table)
         mock_update_filters.assert_called_once_with([],
                                                     'Exclude',
-                                                    self.log_table)
+                                                    self.log_table,
+                                                    0)
 
     def test_make_plot_two_logs_and_time(self):
         self.presenter._plot.new_plot = mock.Mock()
@@ -203,6 +205,7 @@ class ControlPanePresenterTest(TestHelper):
 
         self.presenter.make_plot(time_data,
                                  self.log_table,
+                                 0,
                                  'Exclude')
 
         self.presenter._plot.new_plot.assert_called_once_with(['Temp', 'B'],
@@ -210,7 +213,8 @@ class ControlPanePresenterTest(TestHelper):
 
         mock_update_filters.assert_called_once_with(time_data,
                                                     'Exclude',
-                                                    self.log_table)
+                                                    self.log_table,
+                                                    0)
         self.presenter.add_filters.assert_called_once_with('time', 'log',
                                                            self.log_table)
 
@@ -467,7 +471,7 @@ class ControlPanePresenterTest(TestHelper):
         self.check_hover_text(result[2], expect)
 
     def test_read_filter(self):
-        data, log_data, state, cols = self.presenter.read_filter(FILTER)
+        data, log_data, amp, state, cols = self.presenter.read_filter(FILTER)
         self.assertEqual(state, 'Include')
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0], {'Name' + TT: 'first',
@@ -486,6 +490,7 @@ class ControlPanePresenterTest(TestHelper):
                            'y_min' + LT: 35.0,
                            'y_max' + LT: 39.0}])
 
+        self.assertEqual(amp, 3.14)
         # this is the only bit that can change
         self.assertEqual(cols[2]['headerName'], 'Include Filter details')
 

--- a/test/GUI/filters/filters_presenter_test.py
+++ b/test/GUI/filters/filters_presenter_test.py
@@ -30,8 +30,21 @@ class FilterPresenterTest(TestHelper):
         """
         self.presenter._time_file_data = 'time'
         self.presenter._log_file_data = 'log'
+        self.presenter._amp_file_data = 2
 
-        self.assertFalse(self.presenter.show_file(name, 'time', 'log'))
+        self.assertFalse(self.presenter.show_file(name, 'time', 'log', 2))
+
+    def test_show_file_match_amp_fails(self):
+        name = 'test.json'
+        """
+        lets use fake values (should be dicts,
+        but just checks they match)
+        """
+        self.presenter._time_file_data = 'time'
+        self.presenter._log_file_data = 'log'
+        self.presenter._amp_file_data = 2
+
+        self.assertTrue(self.presenter.show_file(name, 'time', 'log', 4))
 
     def test_show_file_time_match(self):
         name = 'test.json'
@@ -41,8 +54,9 @@ class FilterPresenterTest(TestHelper):
         """
         self.presenter._time_file_data = 'time'
         self.presenter._log_file_data = 'log'
+        self.presenter._amp_file_data = 2
 
-        self.assertTrue(self.presenter.show_file(name, 'time', 'new'))
+        self.assertTrue(self.presenter.show_file(name, 'time', 'new', 2))
 
     def test_show_file_log_match(self):
         name = 'test.json'
@@ -52,8 +66,9 @@ class FilterPresenterTest(TestHelper):
         """
         self.presenter._time_file_data = 'time'
         self.presenter._log_file_data = 'log'
+        self.presenter._amp_file_data = 2
 
-        self.assertTrue(self.presenter.show_file(name, 'new', 'log'))
+        self.assertTrue(self.presenter.show_file(name, 'new', 'log', 2))
 
     def test_show_file_no_match(self):
         name = 'test.json'
@@ -63,8 +78,9 @@ class FilterPresenterTest(TestHelper):
         """
         self.presenter._time_file_data = 'time'
         self.presenter._log_file_data = 'log'
+        self.presenter._amp_file_data = 2
 
-        self.assertTrue(self.presenter.show_file(name, 'unit', 'test'))
+        self.assertTrue(self.presenter.show_file(name, 'unit', 'test', 3))
 
     def test_headers(self):
         self.assertEqual(len(self.presenter.headers), 3)
@@ -102,7 +118,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters(filters,
                                      'Include',
-                                     [])
+                                     [],
+                                     0)
         result = self.presenter._data.report_filters()
 
         expect = [0, {}, {}, {}]
@@ -119,7 +136,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters(filters,
                                      'Include',
-                                     [])
+                                     [],
+                                     0)
         result = self.presenter._data.report_filters()
 
         expect = [0,
@@ -140,7 +158,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters(filters,
                                      'Exclude',
-                                     [])
+                                     [],
+                                     0)
         result = self.presenter._data.report_filters()
         expect = [0,
                   {},
@@ -159,7 +178,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters([],
                                      'Exclude',
-                                     filters)
+                                     filters,
+                                     0)
         result = self.presenter._data.report_filters()
         expect = [0,
                   {'Temp': [1, 11]},
@@ -177,7 +197,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters([],
                                      'Exclude',
-                                     filters)
+                                     filters,
+                                     0)
         result = self.presenter._data.report_filters()
         expect = [0,
                   {'Temp': [4, -999]},
@@ -195,7 +216,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters([],
                                      'Exclude',
-                                     filters)
+                                     filters,
+                                     0)
         result = self.presenter._data.report_filters()
         expect = [0,
                   {'Temp': [-999, 7]},
@@ -220,7 +242,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters(times,
                                      'Exclude',
-                                     logs)
+                                     logs,
+                                     0)
         result = self.presenter._data.report_filters()
         expect = [0,
                   {'Temp': [2, 7]},
@@ -241,7 +264,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         start, stop, msg = self.presenter.update_filters(times,
                                                          'Exclude',
-                                                         {})
+                                                         {},
+                                                         0)
         self.assertEqual(msg, '')
         self.assertArrays(start, [0.994])
         self.assertArrays(stop, [1.194])
@@ -255,7 +279,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         start, stop, msg = self.presenter.update_filters([],
                                                          'Exclude',
-                                                         logs)
+                                                         logs,
+                                                         0)
         self.assertEqual(msg, '')
         self.assertArrays(start, [0.994])
         self.assertArrays(stop, [3.174])
@@ -264,7 +289,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         start, stop, msg = self.presenter.update_filters([],
                                                          'Exclude',
-                                                         [])
+                                                         [],
+                                                         0)
         self.assertEqual(msg, '')
         self.assertArrays(start, [])
         self.assertArrays(stop, [])
@@ -285,7 +311,8 @@ class FilterPresenterTest(TestHelper):
         self.presenter._data = load_events(FILE, 64)
         start, stop, msg = self.presenter.update_filters(times,
                                                          'Exclude',
-                                                         logs)
+                                                         logs,
+                                                         0)
         self.assertEqual(msg, '')
         self.assertArrays(start, [0.994])
         self.assertArrays(stop, [3.174])
@@ -340,7 +367,7 @@ class FilterPresenterTest(TestHelper):
 
     def test_calculate_no_filters(self):
         self.presenter._data = load_events(FILE, 64)
-        N_str, err_msg = self.presenter.calculate(1, {}, 'Exclude', [])
+        N_str, err_msg = self.presenter.calculate(1, {}, 'Exclude', [], 0)
         self.assertEqual(err_msg, '')
         self.assertEqual(N_str.children,
                          'Number of events: 64,147')
@@ -348,7 +375,7 @@ class FilterPresenterTest(TestHelper):
     def test_calculate_with_exclude_filter(self):
         self.presenter._data = load_events(FILE, 64)
         filters = [{'Name' + TT: 'unit', 'Start' + TT: 0.1, 'End' + TT: 1.2}]
-        N_str, err_msg = self.presenter.calculate(1, filters, 'Exclude', [])
+        N_str, err_msg = self.presenter.calculate(1, filters, 'Exclude', [], 0)
         self.assertEqual(err_msg, '')
         self.assertEqual(N_str.children,
                          'Number of events: 57,653')
@@ -356,7 +383,7 @@ class FilterPresenterTest(TestHelper):
     def test_calculate_with_include_filter(self):
         self.presenter._data = load_events(FILE, 64)
         filters = [{'Name' + TT: 'unit', 'Start' + TT: 0.1, 'End' + TT: 1.2}]
-        N_str, err_msg = self.presenter.calculate(1, filters, 'Include', [])
+        N_str, err_msg = self.presenter.calculate(1, filters, 'Include', [], 0)
         self.assertEqual(err_msg, '')
         self.assertEqual(N_str.children,
                          'Number of events: 5,037')
@@ -368,19 +395,19 @@ class FilterPresenterTest(TestHelper):
                 'y0' + LT: 35.5,
                 'yN' + LT: 37}]
 
-        N_str, err_msg = self.presenter.calculate(1, [], 'Include', log)
+        N_str, err_msg = self.presenter.calculate(1, [], 'Include', log, 0)
         self.assertEqual(err_msg, '')
         self.assertEqual(N_str.children,
                          'Number of events: 57,481')
 
     def test_calculate_with_error(self):
-        def throw(filters, state, log):
+        def throw(filters, state, log, amp):
             raise RuntimeError("mock throw")
 
         self.presenter._data = load_events(FILE, 64)
         self.presenter.apply_filters = mock.Mock(side_effect=throw)
         filters = [{'Name_t': 'unit', 'Start_t': 0.1, 'End_t': 1.2}]
-        N_str, err_msg = self.presenter.calculate(1, filters, 'Include', [])
+        N_str, err_msg = self.presenter.calculate(1, filters, 'Include', [], 0)
         self.assertEqual(err_msg, 'mock throw')
         self.assertEqual(N_str.children,
                          'Number of events: 0')
@@ -394,7 +421,7 @@ class FilterPresenterTest(TestHelper):
 
         _data = load_events(FILE, 64)
         self.presenter.set_data(_data)
-        data, logs, state, headers = self.presenter.load(filters)
+        data, logs, amps, state, headers = self.presenter.load(filters)
         self.assertEqual(state, 'Include')
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0], {'Name' + TT: 'unit',
@@ -412,6 +439,7 @@ class FilterPresenterTest(TestHelper):
                                  'y_max_log-table': np.float64(39.0),
                                  'y_min_log-table': np.float64(35.0)}
                                 ])
+        self.assertEqual(amps, 1.2)
         self.assertEqual(len(headers), 3)
 
     def test_load_exclude(self):
@@ -420,7 +448,7 @@ class FilterPresenterTest(TestHelper):
         filters['time_filters'] = {'keep_filters': {},
                                    'remove_filters': {'more': [5, 6],
                                                       'tests': [7, 8]}}
-        data, logs, state, headers = self.presenter.load(filters)
+        data, logs, amps, state, headers = self.presenter.load(filters)
         self.assertEqual(state, 'Exclude')
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0], {'Name' + TT: 'more',
@@ -430,6 +458,7 @@ class FilterPresenterTest(TestHelper):
                                    'Start' + TT: 7,
                                    'End' + TT: 8})
         self.assertEqual(logs, [])
+        self.assertEqual(amps, 1.2)
         self.assertEqual(len(headers), 3)
 
     def test_load_fail(self):
@@ -440,7 +469,7 @@ class FilterPresenterTest(TestHelper):
                                    'remove_filters': {'more': [5, 6],
                                                       'tests': [7, 8]}}
         with self.assertRaises(RuntimeError):
-            data, state = self.presenter.load(filters)
+            _ = self.presenter.load(filters)
 
     def test_update_N_events_success(self):
         result = self.presenter.update_N_events(True, 'old')

--- a/test/GUI/filters/filters_presenter_test.py
+++ b/test/GUI/filters/filters_presenter_test.py
@@ -372,6 +372,13 @@ class FilterPresenterTest(TestHelper):
         self.assertEqual(N_str.children,
                          'Number of events: 64,147')
 
+    def test_calculate_amp_filter(self):
+        self.presenter._data = load_events(FILE, 64)
+        N_str, err_msg = self.presenter.calculate(1, {}, 'Exclude', [], 2500)
+        self.assertEqual(err_msg, '')
+        self.assertEqual(N_str.children,
+                         'Number of events: 7,944')
+
     def test_calculate_with_exclude_filter(self):
         self.presenter._data = load_events(FILE, 64)
         filters = [{'Name' + TT: 'unit', 'Start' + TT: 0.1, 'End' + TT: 1.2}]

--- a/test/GUI/main_app/main_app_presenter_test.py
+++ b/test/GUI/main_app/main_app_presenter_test.py
@@ -143,7 +143,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], False)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], '')
+        self.assertEqual(result[6], 0)
+        self.assertEqual(result[7], '')
 
         self.assertMockOnce(app.plot, [])
 
@@ -276,7 +277,8 @@ class MainAppPresenterTest(TestHelper):
         _ = app.load_nxs(CURRENT + FILE, [], DEBUG)
         dtype = 'n'
         file_name = 'test.nxs'
-        name, msg = app.save_data(dtype + file_name, [], 'Exclude', [], DEBUG)
+        name, msg = app.save_data(dtype + file_name, [],
+                                  'Exclude', [], 0, DEBUG)
         self.assertTrue(os.path.isfile(file_name))
 
         with h5py.File(file_name, 'r') as file:
@@ -303,6 +305,7 @@ class MainAppPresenterTest(TestHelper):
                                   filters,
                                   'Exclude',
                                   [],
+                                  0,
                                   DEBUG)
         self.assertTrue(os.path.isfile(file_name))
 
@@ -331,6 +334,7 @@ class MainAppPresenterTest(TestHelper):
                                   filters,
                                   'Include',
                                   [],
+                                  0,
                                   DEBUG)
         self.assertTrue(os.path.isfile(file_name))
 
@@ -351,7 +355,8 @@ class MainAppPresenterTest(TestHelper):
         filters = [{'Name' + TT: 'unit_test',
                     'Start' + TT: 1.2,
                     'End' + TT: 200}]
-        name, msg = app.save_data(dtype + file, filters, 'Exclude', [], DEBUG)
+        name, msg = app.save_data(dtype + file, filters,
+                                  'Exclude', [], 0, DEBUG)
 
         with open('test.json') as f:
             result = json.load(f)
@@ -376,7 +381,8 @@ class MainAppPresenterTest(TestHelper):
         filters = [{'Name' + TT: 'unit_test',
                     'Start' + TT: 1.2,
                     'End' + TT: 200}]
-        name, msg = app.save_data(dtype + file, filters, 'Include', [], DEBUG)
+        name, msg = app.save_data(dtype + file, filters, 'Include',
+                                  [], 0, DEBUG)
 
         with open('test.json') as f:
             result = json.load(f)
@@ -404,14 +410,14 @@ class MainAppPresenterTest(TestHelper):
 
         app.load._data.save_filters = mock.Mock(side_effect=throw)
 
-        name, msg = app.save_data(dtype + file, [], ' Exclude', [], DEBUG)
+        name, msg = app.save_data(dtype + file, [], ' Exclude', [], 0, DEBUG)
         self.assertFalse(os.path.isfile(file))
         self.assertEqual(name, '')
         self.assertEqual(str(msg), 'Saving Error: save crash')
 
     def test_save_none(self):
         app = MainAppPresenter(dummy_open)
-        result = app.save_data('None', [], 'Exclude', [], DEBUG)
+        result = app.save_data('None', [], 'Exclude', [], 0, DEBUG)
         self.assertEqual(result[0], '')
         self.assertEqual(result[1], '')
 

--- a/test/GUI/main_app/main_app_presenter_test.py
+++ b/test/GUI/main_app/main_app_presenter_test.py
@@ -80,7 +80,7 @@ class MainAppPresenterTest(TestHelper):
 
         app = MainAppPresenter(dummy_open)
         app.plot = mock.Mock(return_value='plot')
-
+        app.plot_amps = mock.Mock(return_value='amps')
         result = app.load_nxs(CURRENT + FILE, [], [], DEBUG)
         self.assertEqual(result[0], 'plot')
         self.assertEqual(result[1], [])
@@ -88,7 +88,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], False)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], '')
+        self.assertEqual(result[6], 'amps')
+        self.assertEqual(result[7], '')
 
         self.assertMockOnce(app.plot, [])
 
@@ -106,7 +107,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], True)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6],
+        self.assertEqual(result[6], {})
+        self.assertEqual(result[7],
                          'An error occurred: '
                          'The file HIFI0.nxs cannot be read')
 
@@ -125,7 +127,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], True)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], '')
+        self.assertEqual(result[6], {})
+        self.assertEqual(result[7], '')
 
         self.assertMockOnce(app.plot, [])
 
@@ -133,7 +136,7 @@ class MainAppPresenterTest(TestHelper):
 
         app = MainAppPresenter(dummy_open)
         app.plot = mock.Mock(return_value='plot')
-
+        app.plot_amps = mock.Mock(return_value='amps')
         filters = [{'Name' + TT: 'test', 'Start' + TT: 0, 'End' + TT: 1}]
         logs = [{'Delete_log-table': '',
                  'Name_log-table': 'mag_field',
@@ -146,14 +149,13 @@ class MainAppPresenterTest(TestHelper):
                  'y_max_log-table': 3}]
 
         result = app.load_nxs(CURRENT + FILE, filters, logs, DEBUG)
-        self.assertEqual(result[0], 'plot')
         # should clear the filters
         self.assertEqual(result[1], [])
         self.assertEqual(result[2], False)
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], False)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], 0)
+        self.assertEqual(result[6], 'amps')
         self.assertEqual(result[7], '')
 
         self.assertMockOnce(app.plot, [])
@@ -164,6 +166,7 @@ class MainAppPresenterTest(TestHelper):
 
         result = app.load_nxs(CURRENT + FILE, [], [], DEBUG)
         plot = result[0]
+        amps = result[6]
 
         # add some filters after load
         filters = [{'Name' + TT: 'test', 'Start' + TT: 0, 'End' + TT: 1}]
@@ -185,7 +188,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], logs)
         self.assertEqual(result[4], False)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], '')
+        self.assertEqual(result[6], amps)
+        self.assertEqual(result[7], '')
 
     def test_load_nxs_fails_with_filters(self):
 
@@ -213,7 +217,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], True)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6],
+        self.assertEqual(result[6], {})
+        self.assertEqual(result[7],
                          'An error occurred: '
                          'The file HIFI0.nxs cannot be read')
 
@@ -244,7 +249,8 @@ class MainAppPresenterTest(TestHelper):
         self.assertEqual(result[3], [])
         self.assertEqual(result[4], True)
         self.assertEqual(len(result[5]), 3)
-        self.assertEqual(result[6], '')
+        self.assertEqual(result[6], {})
+        self.assertEqual(result[7], '')
 
         self.assertMockOnce(app.plot, [])
 
@@ -255,9 +261,10 @@ class MainAppPresenterTest(TestHelper):
 
         self.assertEqual(result[0], [])
         self.assertEqual(result[1], [])
-        self.assertEqual(result[2], 'Exclude')
-        self.assertEqual(len(result[3]), 3)
-        self.assertEqual(result[4], 'Load filter error: Cannot have '
+        self.assertEqual(result[2], 0)
+        self.assertEqual(result[3], 'Exclude')
+        self.assertEqual(len(result[4]), 3)
+        self.assertEqual(result[5], 'Load filter error: Cannot have '
                          'both include and exclude time filters')
 
     def test_load_filter(self):
@@ -281,9 +288,10 @@ class MainAppPresenterTest(TestHelper):
                                       'y_min_log-table': np.float64(35.0)
                                       }])
 
-        self.assertEqual(result[2], 'Include')
-        self.assertEqual(len(result[3]), 3)
-        self.assertEqual(result[4], '')
+        self.assertEqual(result[2], 3.14)
+        self.assertEqual(result[3], 'Include')
+        self.assertEqual(len(result[4]), 3)
+        self.assertEqual(result[5], '')
 
     def test_load_filter_fail(self):
         bad_file = 'filters.json'
@@ -294,9 +302,10 @@ class MainAppPresenterTest(TestHelper):
 
         self.assertEqual(result[0], [])
         self.assertEqual(result[1], [])
-        self.assertEqual(result[2], 'Exclude')
-        self.assertEqual(len(result[3]), 3)
-        self.assertEqual(result[4], "Load filter error: "
+        self.assertEqual(result[2], 0)
+        self.assertEqual(result[3], 'Exclude')
+        self.assertEqual(len(result[4]), 3)
+        self.assertEqual(result[5], "Load filter error: "
                          "[Errno 2] No such file or "
                          f"directory: '{bad_file}'")
 
@@ -320,9 +329,10 @@ class MainAppPresenterTest(TestHelper):
 
         self.assertEqual(result[0], [])
         self.assertEqual(result[1], [])
-        self.assertEqual(result[2], 'Exclude')
-        self.assertEqual(len(result[3]), 3)
-        self.assertEqual(result[4], "Load filter error: "
+        self.assertEqual(result[2], 0)
+        self.assertEqual(result[3], 'Exclude')
+        self.assertEqual(len(result[4]), 3)
+        self.assertEqual(result[5], "Load filter error: "
                          "[Errno 2] No such file or "
                          f"directory: '{bad_file}'")
 


### PR DESCRIPTION
<!-- Please use a descriptive name for the PR.
It will be used for the automated release notes along with the labels.
The labels that are used are:
 - ignore-for-release-notes
 - Data Loader
 - Maintenance
 - New Feature
 - bug
-->

### Description of work
This PR adds some basic amplitude filtering. It is limited to a single value for all detectors. The filters work with the load/save filters and calculate/save histograms. 

This is dependent on #82 
#### Summary of work
<!-- Please provide a short, high level description of the work that was done.
-->

<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
#### Purpose of work
This can be removed if a github issue is referenced below
-->

*There is no associated issue.*


### To test:

Open the GUI and load your favourite data set
Click calculate
Press `Save`
Expand the amplitude section and you will see a nice plot
Pick a value from the plot to filter from (e.g. 2500)
Click calculate, notice that the number of events is less
Press `Save`, but give the fail a different name

In a hdf5 reader look at the counts for both saved files. The one with the filter should have more 0's. 

#### Code Review

- Is the code of an acceptable quality?
- Are the unit tests small and test the class in isolation?
- Does the documentation build [ReadTheDocs](https://readthedocs.org/projects/muondatalib/builds/)?

#### Functional Tests

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**.

