### PR TITLE
Change linter to ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Flake8
+name: lint 
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
   release:
 
 jobs:
-  flake8:
+  ruff:
     runs-on: ubuntu-slim
 
     steps:
@@ -21,5 +21,5 @@ jobs:
 
       - name: set up python
         uses: actions/setup-python@v2
-      - name: check flake8
-        uses: py-actions/flake8@v2
+      - name: lint with ruff
+        uses: astral-sh/ruff-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,8 @@ description = 'Reading and writing for ISIS muon experiments.'
 readme = 'README.md'
 license = {text = 'BSD'}
 
+[tool.ruff]
+line-length = 79
+
+[tool.ruff.lint]
+extend-select = ["E", "W"]


### PR DESCRIPTION
Fixes #94 by changing the linter to `ruff`. The default `ruff` rules are designed to be a drop-in replacement for flake8, so the lints pass with default rules. I've also added the `E` and `W` rulesets which are the `pycodestyle` rulesets. 

Let me know if you'd like to [add any extra](https://docs.astral.sh/ruff/rules/).