### PR TITLE
Refactor column class into subclasses for each dtype

### DIFF
--- a/src/MuonDataLib/GUI/log/presenter.py
+++ b/src/MuonDataLib/GUI/log/presenter.py
@@ -2,7 +2,9 @@ from MuonDataLib.data.utils import NONE
 from MuonDataLib.GUI.table.presenter import TablePresenter
 from MuonDataLib.GUI.log.view import LogView
 from MuonDataLib.GUI.table.column import (DropDownColumn,
-                                          Column,
+                                          TextColumn,
+                                          ButtonColumn,
+                                          NumericColumn,
                                           TableGroup,
                                           TableColumns)
 from MuonDataLib.GUI.plot_area.presenter import PlotAreaPresenter
@@ -38,12 +40,12 @@ class LogPresenter(TablePresenter):
         self._plot = PlotAreaPresenter('log')
 
         # create table
-        name = Column('Name_' + LOG_TABLE, 'Name', 'text')
+        name = TextColumn('Name_' + LOG_TABLE, 'Name')
 
-        log = Column('change_btn_' + LOG_TABLE, '', 'button')
+        log = ButtonColumn('change_btn_' + LOG_TABLE, '')
         log.set_icon(icon='bi bi-graph-up me-2', class_name='btn btn-primary')
 
-        sample = Column('sample_' + LOG_TABLE, 'selected', 'text')
+        sample = TextColumn('sample_' + LOG_TABLE, 'selected')
         sample.set_uneditable()
 
         filter_selector = DropDownColumn('filter_' + LOG_TABLE, 'Filter type',
@@ -52,11 +54,11 @@ class LogPresenter(TablePresenter):
         we need an extra magic col as we cannot get the value from the
         dropdown in conditional formatting
         """
-        magic = Column('magic', '', 'text')
+        magic = TextColumn('magic', '')
         magic.hide()
 
-        filter_start = Column('y0_' + LOG_TABLE, 'Keep data from', 'numeric')
-        filter_end = Column('yN_' + LOG_TABLE, 'Keep data to', 'numeric')
+        filter_start = NumericColumn('y0_' + LOG_TABLE, 'Keep data from')
+        filter_end = NumericColumn('yN_' + LOG_TABLE, 'Keep data to')
 
         filter_start.set_condition({"styleConditions": [
             {"condition": "params.data.magic == 'below'",
@@ -73,9 +75,9 @@ class LogPresenter(TablePresenter):
                  })
 
         # want the min and max y values in the row data to make it easier.
-        y_min = Column('y_min_' + LOG_TABLE, 'y min', 'numeric')
+        y_min = NumericColumn('y_min_' + LOG_TABLE, 'y min')
         y_min.hide()
-        y_max = Column('y_max_' + LOG_TABLE, 'y max', 'numeric')
+        y_max = NumericColumn('y_max_' + LOG_TABLE, 'y max')
         y_max.hide()
         cols = TableColumns([TableGroup([name]),
                              TableGroup([log, sample], 'Sample logs'),

--- a/src/MuonDataLib/GUI/log/presenter.py
+++ b/src/MuonDataLib/GUI/log/presenter.py
@@ -48,8 +48,7 @@ class LogPresenter(TablePresenter):
         sample = TextColumn('sample_' + LOG_TABLE, 'selected')
         sample.set_uneditable()
 
-        filter_selector = DropDownColumn('filter_' + LOG_TABLE, 'Filter type',
-                                         ['above', 'between', 'below'])
+        filter_selector = DropDownColumn('filter_' + LOG_TABLE, 'Filter type')
         """
         we need an extra magic col as we cannot get the value from the
         dropdown in conditional formatting

--- a/src/MuonDataLib/GUI/table/column.py
+++ b/src/MuonDataLib/GUI/table/column.py
@@ -160,7 +160,7 @@ class DropDownColumn(Column):
     This needs to be cleaned up along
     with the above.
     """
-    def __init__(self, ID, name, options):
+    def __init__(self, ID, name, options=None):
         """
         Create the details for the column.
         The min and max are only for the numeric

--- a/src/MuonDataLib/GUI/table/column.py
+++ b/src/MuonDataLib/GUI/table/column.py
@@ -82,7 +82,6 @@ class TextColumn(Column):
     """
     A column subclass for storing text data.
     """
-
     def get_cell_config(self):
         return {
             'cellEditor': 'agLargeTextCellEditor',
@@ -155,26 +154,9 @@ class ButtonColumn(Column):
 
 class DropDownColumn(Column):
     """
-    A simple class for creating a dropdown
+    A simple class for creating dropdown
     columns for a dash data ag-table.
-    This needs to be cleaned up along
-    with the above.
     """
-    def __init__(self, ID, name, options=None):
-        """
-        Create the details for the column.
-        The min and max are only for the numeric
-        data type and provide the limits
-        for the values that can be entered.
-        :param ID: the ID for the column
-        :param name: the displayed name in the
-        column.
-        :param options: the options for the drop
-        down menu
-        """
-        super().__init__(ID, name)
-        self._options = options
-
     def get_cell_config(self):
         return {
            "cellEditor": "agSelectCellEditor",

--- a/src/MuonDataLib/GUI/table/column.py
+++ b/src/MuonDataLib/GUI/table/column.py
@@ -1,71 +1,31 @@
-class Column(object):
+from abc import ABC, abstractmethod
+
+
+class Column(ABC):
     """
     A simple class for creating columns for
     a dash data ag-table. This stores the extra
     information (e.g. dropdowns, validation,
     conditional formating).
     """
-    def __init__(self, ID, name, dtype):
+    def __init__(self, ID, name):
         """
         Create the details for the column.
-        The min and max are only for the numeric
-        data type and provide the limits
-        for the values that can be entered.
         :param ID: the ID for the column
         :param name: the displayed name in the
         column.
-        :param dtype: the data type for the column
-        (allowed values; text, numeric, button)
         """
-        if dtype in ['text', 'numeric', 'button']:
-            self.ID = ID
-            self.name = name
-            self.dtype = dtype
-            self._editable = True
-            self._con = None
-            self._hide = False
-            # set default range for numeric data
-            self._min = -1e6
-            self._max = 1e6
-            # set default button values (delete)
-            self._icon = 'bi bi-trash me-2'
-            self._className = 'btn btn-danger'
-        else:
-            raise ValueError(f"Unkown column dtype {dtype}."
-                             "Options are 'text', 'numeric' and 'button'.")
+        self.ID = ID
+        self.name = name
+        self._editable = True
+        self._con = None
+        self._hide = False
 
     def set_uneditable(self):
         """
         A method to make the column uneditable
         """
         self._editable = False
-
-    def set_icon(self, icon, class_name):
-        """
-        A method to set the column's button to a
-        custom one.
-        :param icon: the code for the button image
-        see https://icons.getbootstrap.com/
-        :param class_name: the class name
-        for the button (sets colour)
-        """
-        self._icon = icon
-        self._className = class_name
-
-    def set_range(self, min_value, max_value):
-        """
-        Sets the range of allowed values for a numeric
-        cell.
-        :param min_value: the smallest allowed value
-        :param max_value: the largest allowed value
-        """
-        if self.is_numeric:
-            if min_value > max_value:
-                raise RuntimeError("col range: Min value > Max value")
-            self._min = min_value
-            self._max = max_value
-        else:
-            raise RuntimeError('Cannot set col range for non-numeric dtype')
 
     def set_condition(self, condition):
         """
@@ -102,35 +62,95 @@ class Column(object):
                'width': 100,
                'editable': self._editable,
                'hide': self._hide}
-        if self.dtype == 'text':
-            col['cellEditor'] = 'agLargeTextCellEditor'
-            col['cellEditorPopup'] = False
-            col['cellEditorParams'] = {'maxLength': 50}
-
-        elif self.dtype == 'numeric':
-            col['cellEditor'] = 'agNumberCellEditor'
-            col['cellEditorParams'] = {'min': self._min,
-                                       'max': self._max,
-                                       'precision': 5}
-        elif self.dtype == 'button':
-            col['editable'] = False
-            col['cellRenderer'] = 'Button'
-            col['cellRendererParams'] = {'Icon': self._icon,
-                                         'className': self._className}
+        col.update(self.get_cell_config())
 
         if self._con is not None:
             col['cellStyle'] = self._con
         return col
 
-    @property
-    def is_numeric(self):
+    @abstractmethod
+    def get_cell_config(self):
         """
-        Checks if a cell is numeric
-        :returns: a bool for if its numeric.
+        Get dash cell configuration details
+        for a specific data type.
+        :returns: the config for the specific cell type
         """
-        if self.dtype == 'numeric':
-            return True
-        return False
+        raise NotImplementedError
+
+
+class TextColumn(Column):
+    """
+    A column subclass for storing text data.
+    """
+
+    def get_cell_config(self):
+        return {
+            'cellEditor': 'agLargeTextCellEditor',
+            'cellEditorPopup': False,
+            'cellEditorParams': {'maxLength': 50},
+            }
+
+
+class NumericColumn(Column):
+    """
+    A column subclass for storing numeric data.
+    """
+    def __init__(self, ID, name):
+        super().__init__(ID, name)
+        self._min = -1e6
+        self._max = 1e6
+
+    def get_cell_config(self):
+        return {
+            'cellEditor': 'agNumberCellEditor',
+            'cellEditorParams': {'min': self._min,
+                                 'max': self._max,
+                                 'precision': 5}
+            }
+
+    def set_range(self, min_value, max_value):
+        """
+        Sets the range of allowed values for a numeric
+        cell.
+        :param min_value: the smallest allowed value
+        :param max_value: the largest allowed value
+        """
+        if min_value > max_value:
+            raise ValueError("col range: Min value > Max value")
+        self._min = min_value
+        self._max = max_value
+
+
+class ButtonColumn(Column):
+    """
+    A column subclass for storing buttons.
+    """
+    def __init__(self, ID, name):
+        super().__init__(ID, name)
+        # set default button values (delete)
+        self._icon = 'bi bi-trash me-2'
+        self._className = 'btn btn-danger'
+
+    def get_cell_config(self):
+        return {
+            'editable': False,
+            'cellRenderer': 'Button',
+            'cellRendererParams': {'Icon': self._icon,
+                                   'className': self._className}
+
+            }
+
+    def set_icon(self, icon, class_name):
+        """
+        A method to set the column's button to a
+        custom one.
+        :param icon: the code for the button image
+        see https://icons.getbootstrap.com/
+        :param class_name: the class name
+        for the button (sets colour)
+        """
+        self._icon = icon
+        self._className = class_name
 
 
 class DropDownColumn(Column):
@@ -152,32 +172,15 @@ class DropDownColumn(Column):
         :param options: the options for the drop
         down menu
         """
-        self.ID = ID
-        self.name = name
+        super().__init__(ID, name)
         self._options = options
 
-    @property
-    def get_column_dict(self):
-        """
-        This method generates a dict
-        for the config of the column.
-        :returns: the dict of the config
-        """
-        col = {'field': self.ID,
-               'headerName': self.name,
-               "cellEditor": "agSelectCellEditor",
-               "cellEditorParams": {"values": ["above", "between", "below"]},
-               'singleClickEdit': True,
-               'width': 100}
-        return col
-
-    @property
-    def is_numeric(self):
-        """
-        Checks if a cell is numeric
-        :returns: a bool for if its numeric.
-        """
-        return False
+    def get_cell_config(self):
+        return {
+           "cellEditor": "agSelectCellEditor",
+           "cellEditorParams": {"values": ["above", "between", "below"]},
+           'singleClickEdit': True,
+            }
 
 
 class TableGroup(object):
@@ -218,7 +221,7 @@ class TableGroup(object):
         :param max_value: the largst allowed value
         """
         for col in self.cols:
-            if col.is_numeric:
+            if isinstance(col, NumericColumn):
                 col.set_range(min_value,
                               max_value)
 
@@ -260,8 +263,7 @@ class TableColumns(object):
             raise RuntimeError('Need to include an ID '
                                'for the delete button')
         elif inc_delete_row:
-            self.cols = [TableGroup([Column('Delete_' + btn_ID,
-                                            '', 'button')])]
+            self.cols = [TableGroup([ButtonColumn('Delete_' + btn_ID, '')])]
 
         if isinstance(col_groups, list):
             for tmp in col_groups:

--- a/src/MuonDataLib/GUI/time/presenter.py
+++ b/src/MuonDataLib/GUI/time/presenter.py
@@ -1,6 +1,9 @@
 from MuonDataLib.GUI.table.presenter import TablePresenter
 from MuonDataLib.GUI.time.view import TimeView
-from MuonDataLib.GUI.table.column import Column, TableGroup, TableColumns
+from MuonDataLib.GUI.table.column import (TextColumn,
+                                          NumericColumn,
+                                          TableGroup,
+                                          TableColumns)
 
 
 TIME_TABLE = 'time-table'
@@ -20,10 +23,10 @@ class TimePresenter(TablePresenter):
         self._previous = 'Exclude'
 
         # create columns
-        name = Column('Name_' + TIME_TABLE, 'Name', 'text')
+        name = TextColumn('Name_' + TIME_TABLE, 'Name')
 
-        start = Column('Start_' + TIME_TABLE, 'Start', 'numeric')
-        end = Column('End_' + TIME_TABLE, 'End', 'numeric')
+        start = NumericColumn('Start_' + TIME_TABLE, 'Start')
+        end = NumericColumn('End_' + TIME_TABLE, 'End')
 
         cols = TableColumns([TableGroup([name]),
                              TableGroup([start,

--- a/src/MuonDataLib/test_helpers/table_ref_data.py
+++ b/src/MuonDataLib/test_helpers/table_ref_data.py
@@ -1,7 +1,9 @@
-from MuonDataLib.GUI.table.column import TableGroup, Column
+from MuonDataLib.GUI.table.column import (TableGroup,
+                                          TextColumn,
+                                          NumericColumn,
+                                          ButtonColumn)
 
-
-VALID_DTYPES = ['text', 'numeric', 'button']
+VALID_DTYPES = [TextColumn, NumericColumn, ButtonColumn]
 
 
 def expected_col_dict(dtype, ID='unit', name='test'):
@@ -9,19 +11,19 @@ def expected_col_dict(dtype, ID='unit', name='test'):
            'headerName': name,
            'width': 100,
            'hide': False}
-    if dtype == 'text':
+    if dtype == TextColumn:
         col['cellEditor'] = 'agLargeTextCellEditor'
         col['cellEditorPopup'] = False
         col['cellEditorParams'] = {'maxLength': 50}
         col['editable'] = True
 
-    elif dtype == 'numeric':
+    elif dtype == NumericColumn:
         col['cellEditor'] = 'agNumberCellEditor'
         col['cellEditorParams'] = {'min': -1000000,
                                    'max': 1000000,
                                    'precision': 5}
         col['editable'] = True
-    elif dtype == 'button':
+    elif dtype == ButtonColumn:
         col['editable'] = False
         col['cellRenderer'] = 'Button'
         col['cellRendererParams'] = {'Icon': 'bi bi-trash me-2',
@@ -29,24 +31,23 @@ def expected_col_dict(dtype, ID='unit', name='test'):
     return col
 
 
-COLS = [[Column('Unit', 'unit', dtype)] for dtype in VALID_DTYPES]
+COLS = [[dtype('Unit', 'unit')] for dtype in VALID_DTYPES]
 for dtype1 in VALID_DTYPES:
     for dtype2 in VALID_DTYPES:
-        COLS.append([Column('Unit', 'unit', dtype1),
-                     Column('Test', 'test', dtype2)])
+        COLS.append([dtype1('Unit', 'unit'),
+                     dtype2('Test', 'test')])
 
 TIME_TABLE = ''
-name = Column('Name_' + TIME_TABLE, 'Name', 'text')
-start = Column('Start_' + TIME_TABLE, 'Start', 'numeric')
-end = Column('End_' + TIME_TABLE, 'End', 'numeric')
+name = TextColumn('Name_' + TIME_TABLE, 'Name')
+start = NumericColumn('Start_' + TIME_TABLE, 'Start')
+end = NumericColumn('End_' + TIME_TABLE, 'End')
 
-COL_GROUPS = [[TableGroup([Column('Unit',
-                                  'unit',
-                                  dtype)])] for dtype in VALID_DTYPES]
+COL_GROUPS = [[TableGroup([dtype('Unit', 'unit')])]
+              for dtype in VALID_DTYPES]
 
 for dtype2 in VALID_DTYPES:
-    c1 = Column('Unit', 'unit', dtype1)
-    c2 = Column('Test', 'test', dtype2)
-    c3 = Column('More', 'more', 'text')
+    c1 = dtype1('Unit', 'unit')
+    c2 = dtype2('Test', 'test')
+    c3 = TextColumn('More', 'more')
     COL_GROUPS.append([TableGroup([c2, c3], 'group'),
                        TableGroup([c1])])

--- a/src/MuonDataLib/test_helpers/table_ref_data.py
+++ b/src/MuonDataLib/test_helpers/table_ref_data.py
@@ -1,9 +1,10 @@
 from MuonDataLib.GUI.table.column import (TableGroup,
                                           TextColumn,
                                           NumericColumn,
-                                          ButtonColumn)
+                                          ButtonColumn,
+                                          DropDownColumn)
 
-VALID_DTYPES = [TextColumn, NumericColumn, ButtonColumn]
+VALID_DTYPES = [TextColumn, NumericColumn, ButtonColumn, DropDownColumn]
 
 
 def expected_col_dict(dtype, ID='unit', name='test'):
@@ -28,6 +29,11 @@ def expected_col_dict(dtype, ID='unit', name='test'):
         col['cellRenderer'] = 'Button'
         col['cellRendererParams'] = {'Icon': 'bi bi-trash me-2',
                                      'className': 'btn btn-danger'}
+    elif dtype == DropDownColumn:
+        col['cellEditor'] = "agSelectCellEditor"
+        col['cellEditorParams'] = {"values": ["above", "between", "below"]}
+        col['singleClickEdit'] = True
+        col['editable'] = True
     return col
 
 

--- a/src/MuonDataLib/test_helpers/table_ref_data.py
+++ b/src/MuonDataLib/test_helpers/table_ref_data.py
@@ -38,22 +38,31 @@ def expected_col_dict(dtype, ID='unit', name='test'):
 
 
 COLS = [[dtype('Unit', 'unit')] for dtype in VALID_DTYPES]
+# expected number of numeric columns in each group
+EXPECTED_NUMERIC = [1 if dtype == NumericColumn else 0
+                    for dtype in VALID_DTYPES]
 for dtype1 in VALID_DTYPES:
     for dtype2 in VALID_DTYPES:
         COLS.append([dtype1('Unit', 'unit'),
                      dtype2('Test', 'test')])
+        num_numeric = 1 if dtype1 == NumericColumn else 0
+        num_numeric += 1 if dtype2 == NumericColumn else 0
+        EXPECTED_NUMERIC.append(num_numeric)
 
 TIME_TABLE = ''
 name = TextColumn('Name_' + TIME_TABLE, 'Name')
 start = NumericColumn('Start_' + TIME_TABLE, 'Start')
 end = NumericColumn('End_' + TIME_TABLE, 'End')
 
-COL_GROUPS = [[TableGroup([dtype('Unit', 'unit')])]
-              for dtype in VALID_DTYPES]
+COL_GROUPS = []
+for dtype in VALID_DTYPES:
+    COL_GROUPS.append([TableGroup([dtype('Unit', 'unit')])])
 
-for dtype2 in VALID_DTYPES:
-    c1 = dtype1('Unit', 'unit')
-    c2 = dtype2('Test', 'test')
-    c3 = TextColumn('More', 'more')
-    COL_GROUPS.append([TableGroup([c2, c3], 'group'),
-                       TableGroup([c1])])
+for dtype1 in VALID_DTYPES:
+    for dtype2 in VALID_DTYPES:
+        c1 = dtype1('Unit', 'unit')
+        c2 = dtype2('Test', 'test')
+        c3 = TextColumn('More', 'more')
+        COL_GROUPS.append([TableGroup([c2, c3], 'group'),
+                           TableGroup([c1])])
+

--- a/test/GUI/table/column_test.py
+++ b/test/GUI/table/column_test.py
@@ -1,5 +1,5 @@
 import unittest
-from MuonDataLib.GUI.table.column import Column
+from MuonDataLib.GUI.table.column import ButtonColumn, NumericColumn
 from MuonDataLib.test_helpers.unit_test import TestHelper
 from MuonDataLib.test_helpers.table_ref_data import VALID_DTYPES as VALID
 from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
@@ -7,26 +7,8 @@ from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
 
 class ColumnTest(TestHelper):
 
-    def test_init(self):
-        for dtype in VALID:
-            with self.subTest(dtpye=dtype):
-                col = Column('unit', 'test', dtype)
-                self.assertEqual(col.ID, 'unit')
-                self.assertEqual(col.name, 'test')
-                self.assertEqual(col.dtype, dtype)
-                self.assertEqual(col._min, -1e6)
-                self.assertEqual(col._max, 1e6)
-
-    def test_init_bad_dtype(self):
-        try:
-            _ = Column('unit', 'test', 'bool')
-        except ValueError:
-            pass
-            return
-        self.fail('A bool dtype should not be allowed')
-
     def test_set_icon(self):
-        col = Column('unit', 'test', 'button')
+        col = ButtonColumn('unit', 'test')
         self.assertEqual(col._icon, 'bi bi-trash me-2')
         self.assertEqual(col._className, 'btn btn-danger')
 
@@ -42,46 +24,27 @@ class ColumnTest(TestHelper):
 
     def test_set_uneditable(self):
         for dtype in VALID:
-            with self.subTest(dtpye=dtype):
-                col = Column('unit', 'test', dtype)
+            with self.subTest(dtype=dtype):
+                col = dtype('unit', 'test')
                 data = col.get_column_dict
-                self.assertEqual(data['editable'], dtype != 'button')
+                self.assertEqual(data['editable'],
+                                 not isinstance(col, ButtonColumn))
 
                 col.set_uneditable()
                 data = col.get_column_dict
                 self.assertEqual(data['editable'], False)
 
     def test_set_range(self):
-        for dtype in VALID:
-            with self.subTest(dtpye=dtype):
-                col = Column('unit', 'test', dtype)
-                try:
-                    col.set_range(1.2, 4.7)
-                except RuntimeError:
-                    if dtype == 'numeric':
-                        self.fail('dtype nmeric should not throw an error')
-                    else:
-                        pass
-                        return
-                if dtype != 'numeric':
-                    self.fail(f'dtype {dtype} should not pass')
-                self.assertEqual(col._min, 1.2)
-                self.assertEqual(col._max, 4.7)
+        col = NumericColumn('unit', 'test')
+        col.set_range(1.2, 4.7)
 
-    def test_is_numeric(self):
-        for dtype in VALID:
-            with self.subTest(dtpye=dtype):
-                col = Column('unit', 'test', dtype)
-                state = col.is_numeric
-                if dtype == 'numeric':
-                    self.assertTrue(state)
-                else:
-                    self.assertFalse(state)
+        self.assertEqual(col._min, 1.2)
+        self.assertEqual(col._max, 4.7)
 
     def test_get_column_dict(self):
         for dtype in VALID:
-            with self.subTest(dtpye=dtype):
-                col = Column('unit', 'test', dtype)
+            with self.subTest(dtype=dtype):
+                col = dtype('unit', 'test')
                 col_dict = col.get_column_dict
                 self.assertEqual(col_dict,
                                  expected_col_dict(dtype))

--- a/test/GUI/table/table_col_test.py
+++ b/test/GUI/table/table_col_test.py
@@ -1,5 +1,7 @@
 import unittest
-from MuonDataLib.GUI.table.column import TableColumns
+from MuonDataLib.GUI.table.column import (TableColumns,
+                                          ButtonColumn,
+                                          NumericColumn)
 from MuonDataLib.test_helpers.unit_test import TestHelper
 from MuonDataLib.test_helpers.table_ref_data import COL_GROUPS, COLS
 from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
@@ -49,7 +51,7 @@ class TableColumnsTest(TestHelper):
                 del_btn = del_btn[0]
                 self.assertEqual(del_btn.ID, 'Delete_rm')
                 self.assertEqual(del_btn.name, '')
-                self.assertEqual(del_btn.dtype, 'button')
+                assert isinstance(del_btn, ButtonColumn)
 
     def test_init_fail_add_delete(self):
         for data in COL_GROUPS:
@@ -110,13 +112,9 @@ class TableColumnsTest(TestHelper):
                 table.set_range(1.2, 4.7)
                 for group in table.cols:
                     for col in group.cols:
-                        if col.dtype == 'numeric':
+                        if isinstance(col, NumericColumn):
                             self.assertEqual(col._min, 1.2)
                             self.assertEqual(col._max, 4.7)
-                        else:
-                            # if not numeric these never update (or used)
-                            self.assertEqual(col._min, -1e6)
-                            self.assertEqual(col._max, 1e6)
 
     def test_get_column_dict(self):
         names = ['test', 'more']
@@ -133,13 +131,13 @@ class TableColumnsTest(TestHelper):
                                              'group')
                             children = col_dict[j]['children']
                             self.assertEqual(children[k],
-                                             expected_col_dict(col.dtype,
+                                             expected_col_dict(type(col),
                                                                IDs[k],
                                                                names[k]))
                     else:
                         for col in group.cols:
                             self.assertEqual(col_dict[j],
-                                             expected_col_dict(col.dtype,
+                                             expected_col_dict(type(col),
                                                                'Unit',
                                                                'unit'))
 

--- a/test/GUI/table/table_col_test.py
+++ b/test/GUI/table/table_col_test.py
@@ -3,7 +3,9 @@ from MuonDataLib.GUI.table.column import (TableColumns,
                                           ButtonColumn,
                                           NumericColumn)
 from MuonDataLib.test_helpers.unit_test import TestHelper
-from MuonDataLib.test_helpers.table_ref_data import COL_GROUPS, COLS
+from MuonDataLib.test_helpers.table_ref_data import (COL_GROUPS,
+                                                     COLS,
+                                                     EXPECTED_NUMERIC)
 from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
 
 
@@ -106,8 +108,9 @@ class TableColumnsTest(TestHelper):
                         self.fail("data exists, should be able to set")
 
     def test_set_range(self):
-        for data in COL_GROUPS:
+        for data, expected_numeric in zip(COL_GROUPS, EXPECTED_NUMERIC):
             with self.subTest(data=data):
+                numeric_cols = 0
                 table = TableColumns(data, False)
                 table.set_range(1.2, 4.7)
                 for group in table.cols:
@@ -115,6 +118,8 @@ class TableColumnsTest(TestHelper):
                         if isinstance(col, NumericColumn):
                             self.assertEqual(col._min, 1.2)
                             self.assertEqual(col._max, 4.7)
+                            numeric_cols += 1
+                self.assertEqual(numeric_cols, expected_numeric)
 
     def test_get_column_dict(self):
         names = ['test', 'more']

--- a/test/GUI/table/table_group_test.py
+++ b/test/GUI/table/table_group_test.py
@@ -1,7 +1,7 @@
 import unittest
 from MuonDataLib.GUI.table.column import TableGroup, NumericColumn
 from MuonDataLib.test_helpers.unit_test import TestHelper
-from MuonDataLib.test_helpers.table_ref_data import COLS
+from MuonDataLib.test_helpers.table_ref_data import COLS, EXPECTED_NUMERIC
 from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
 
 
@@ -44,14 +44,17 @@ class TableGroupTest(TestHelper):
                     self.fail('should not allow no name for lists')
 
     def test_set_range(self):
-        for col_list in COLS:
+        for col_list, expected_numeric in zip(COLS, EXPECTED_NUMERIC):
             with self.subTest(col_list=col_list):
+                numeric_cols = 0
                 table = TableGroup(col_list, 'grouping')
                 table.set_range(1.2, 4.7)
                 for col in table.cols:
                     if isinstance(col, NumericColumn):
                         self.assertEqual(col._min, 1.2)
                         self.assertEqual(col._max, 4.7)
+                        numeric_cols += 1
+                self.assertEqual(numeric_cols, expected_numeric)
 
     def test_get_column_dict(self):
         names = ['unit', 'test']

--- a/test/GUI/table/table_group_test.py
+++ b/test/GUI/table/table_group_test.py
@@ -1,5 +1,5 @@
 import unittest
-from MuonDataLib.GUI.table.column import TableGroup
+from MuonDataLib.GUI.table.column import TableGroup, NumericColumn
 from MuonDataLib.test_helpers.unit_test import TestHelper
 from MuonDataLib.test_helpers.table_ref_data import COLS
 from MuonDataLib.test_helpers.table_ref_data import expected_col_dict
@@ -49,13 +49,9 @@ class TableGroupTest(TestHelper):
                 table = TableGroup(col_list, 'grouping')
                 table.set_range(1.2, 4.7)
                 for col in table.cols:
-                    if col.dtype == 'numeric':
+                    if isinstance(col, NumericColumn):
                         self.assertEqual(col._min, 1.2)
                         self.assertEqual(col._max, 4.7)
-                    else:
-                        # if not numeric these never update (or used)
-                        self.assertEqual(col._min, -1e6)
-                        self.assertEqual(col._max, 1e6)
 
     def test_get_column_dict(self):
         names = ['unit', 'test']
@@ -71,7 +67,7 @@ class TableGroupTest(TestHelper):
                     col = data[0]
                     col_dict = data[1]
                     self.assertEqual(col_dict,
-                                     expected_col_dict(col.dtype,
+                                     expected_col_dict(type(col),
                                                        IDs[k],
                                                        names[k]))
 
@@ -99,13 +95,9 @@ class TableGroupTest(TestHelper):
                 table = TableGroup(col_list)
                 table.set_range(1.2, 4.7)
                 for col in table.cols:
-                    if col.dtype == 'numeric':
+                    if isinstance(col, NumericColumn):
                         self.assertEqual(col._min, 1.2)
                         self.assertEqual(col._max, 4.7)
-                    else:
-                        # if not numeric these never update (or used)
-                        self.assertEqual(col._min, -1e6)
-                        self.assertEqual(col._max, 1e6)
 
     def test_get_column_dict_1(self):
         for col_list in SINGLE:
@@ -114,7 +106,7 @@ class TableGroupTest(TestHelper):
                 col_dict_list = table.get_column_dict[0]
                 col = table.cols[0]
                 self.assertEqual(col_dict_list,
-                                 expected_col_dict(col.dtype,
+                                 expected_col_dict(type(col),
                                                    'Unit',
                                                    'unit'))
 

--- a/test/GUI/table/table_presenter_test.py
+++ b/test/GUI/table/table_presenter_test.py
@@ -1,6 +1,9 @@
 import unittest
 from unittest import mock
-from MuonDataLib.GUI.table.column import TableGroup, Column, TableColumns
+from MuonDataLib.GUI.table.column import (TableGroup,
+                                          TextColumn,
+                                          NumericColumn,
+                                          TableColumns)
 from MuonDataLib.GUI.table.presenter import TablePresenter
 from MuonDataLib.test_helpers.unit_test import TestHelper
 
@@ -20,8 +23,8 @@ class TablePresenterTest(TestHelper):
     def setUp(self, view):
         self.view = view
         self.view.return_value = 'widget'
-        cols = TableColumns([TableGroup([Column(NAME, 'name', 'text')]),
-                             TableGroup([Column('Data', 'data', 'numeric')])],
+        cols = TableColumns([TableGroup([TextColumn(NAME, 'name')]),
+                             TableGroup([NumericColumn('Data', 'data')])],
                             False)
         self.presenter = TablePresenterMock('table_test',
                                             cols,


### PR DESCRIPTION
This PR fixes #92 by separating out the column dtypes into their own subclasses of `Column`, and moves methods only relevant to one column type into the subclass. This also simplifies the tests as a few things which had to have custom type/error checking code would now be handled by Python directly. In particular, checks of `col.dtype` and `col.is_numeric` should be replaced by `isinstance` calls.

Changes:
- Made `Column` an abstract base type, removed `dtype` argument, and removed `is_numeric` property
- Added `TextColumn`, `ButtonColumn`, and `NumericColumn` subclasses
- Moved methods and attributes only relevant to one column type into the respective column type, and removed error handling (as trying to use methods on an irrelevant type should now produce an `AttributeError` instead)
- Updated tests and removed tests that are no longer relevant (i.e. tests which would now just be testing Python builtins)

Currently, any subtype is instantiated directly (as previously, dtype strings were hardcoded). #92 wants a single point of entry, which I argue is [currently unnecessary](https://github.com/ISISMuon/MuonDataLib/issues/92#issuecomment-4205093869) but would be easy enough to add if desired.