### PR TITLE
Clear number of events while updating tables

### DIFF
--- a/src/MuonDataLib/GUI/filters/presenter.py
+++ b/src/MuonDataLib/GUI/filters/presenter.py
@@ -1,6 +1,6 @@
 from MuonDataLib.GUI.presenter_template import PresenterTemplate
-from MuonDataLib.GUI.time.presenter import TimePresenter
-from MuonDataLib.GUI.log.presenter import LogPresenter
+from MuonDataLib.GUI.time.presenter import TimePresenter, TIME_TABLE
+from MuonDataLib.GUI.log.presenter import LogPresenter, LOG_TABLE
 from MuonDataLib.GUI.amp.presenter import AmpPresenter
 from MuonDataLib.GUI.filters.view import FilterView
 from MuonDataLib.filters import Filters
@@ -241,18 +241,33 @@ class FilterPresenter(PresenterTemplate):
         print('loading filters ....')
         return time_data, log_data, self._amp_file_data, state, self.headers
 
-    def update_N_events(self, update, current_str):
+    def update_N_events(self, update: list[dict], current_str: str) -> str:
         """
-        A method to provide the correct string to display
-        after an update occurs. We need to clear the
-        number of events if the filters change.
-        :param update: If an update hass occured and is valid
-        :param current_str: the current string for the number
-        of events
-        :returns: the string to display for the number of
-        events
+        Update the events string when the filters are updated.
+        Expects update data in the form returned by
+        the Dash cellValueChanged property.
+        :param update: The filter update data.
+        :param current_str: The current string for the number of events.
+        :returns: The string to display for the number of events.
         """
-        if update:
-            return self._view.no_events_str
-        else:
-            return current_str
+        # I'm not sure if it's even possible
+        # to update multiple cells simultaneously
+        # but we have to unwrap this list anyway
+        # so may as well do it properly
+        for updated_cell in update:
+            col = updated_cell.get('colId', None)
+
+            # if a filter value has changed, we need to clear the string
+            # but we don't if just e.g. name changed
+            update_required = col in ['Start_' + TIME_TABLE,
+                                      'End_' + TIME_TABLE,
+                                      'filter_' + LOG_TABLE,
+                                      'y0_' + LOG_TABLE,
+                                      'yN_' + LOG_TABLE,
+                                      ]
+
+            if update_required:
+                return self._view.no_events_str
+
+        return current_str
+

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -71,6 +71,20 @@ class FilterView(ViewTemplate):
                  State('N_events', 'children'),
                  prevent_initial_call=True)(presenter.update_N_events)
 
+        callback(Output('N_events', 'children', allow_duplicate=True),
+                 [Input('time-table', 'rowData'),
+                 Input('log-table', 'rowData'),
+                 Input('Amp', 'value')],
+                 State('N_events', 'children'),
+                 prevent_initial_call=True)(lambda time_update, log_update,
+                                            amp_update, current_str:
+                                            presenter.update_N_events(
+                                                time_update
+                                                or log_update
+                                                or amp_update,
+                                                current_str)
+                                            )
+
     @property
     def no_events_str(self):
         """

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -76,14 +76,9 @@ class FilterView(ViewTemplate):
                  Input('log-table', 'rowData'),
                  Input('Amp', 'value')],
                  State('N_events', 'children'),
-                 prevent_initial_call=True)(lambda time_update, log_update,
-                                            amp_update, current_str:
-                                            presenter.update_N_events(
-                                                time_update
-                                                or log_update
-                                                or amp_update,
-                                                current_str)
-                                            )
+                 prevent_initial_call=True)(
+                         lambda *ignored: presenter.update_N_events(True, "")
+                         )
 
     @property
     def no_events_str(self):

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -76,9 +76,14 @@ class FilterView(ViewTemplate):
                  Input('log-table', 'rowData'),
                  Input('Amp', 'value')],
                  State('N_events', 'children'),
-                 prevent_initial_call=True)(
-                         lambda *ignored: presenter.update_N_events(True, "")
-                         )
+                 prevent_initial_call=True)(lambda time_update, log_update,
+                                            amp_update, current_str:
+                                            presenter.update_N_events(
+                                                time_update
+                                                or log_update
+                                                or amp_update,
+                                                current_str)
+                                            )
 
     @property
     def no_events_str(self):

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -49,6 +49,7 @@ class FilterView(ViewTemplate):
         Sets the callbacks for the widget
         :param presenter: the presenter for the widget
         """
+        # calculate events when Calculate button is pressed
         callback([Output('N_events', 'children'),
                   Output('error_msg', 'children', allow_duplicate=True)],
                  Input('calc_btn', 'n_clicks'),
@@ -58,6 +59,7 @@ class FilterView(ViewTemplate):
                   State('Amp', 'value')],
                  prevent_initial_call=True)(presenter.calculate)
 
+        # show filename if filter data is equal to that in the file
         callback(Output('title_test', 'hidden'),
                  [Input('title_test', 'children'),
                   Input('time-table', 'rowData'),
@@ -66,24 +68,29 @@ class FilterView(ViewTemplate):
                   ],
                  prevent_initial_call=True)(presenter.show_file)
 
+        # clear events string if time filter changes between include/exclude
         callback(Output('N_events', 'children', allow_duplicate=True),
                  Input('time-table_changed_state', 'data'),
                  State('N_events', 'children'),
+                 prevent_initial_call=True)(lambda *_: self.no_events_str)
+
+        # clear events string if time filter parameters change
+        callback(Output('N_events', 'children', allow_duplicate=True),
+                 Input('time-table', 'cellValueChanged'),
+                 State('N_events', 'children'),
                  prevent_initial_call=True)(presenter.update_N_events)
 
+        # clear events string if log filter parameters change
         callback(Output('N_events', 'children', allow_duplicate=True),
-                 [Input('time-table', 'rowData'),
-                 Input('log-table', 'rowData'),
-                 Input('Amp', 'value')],
+                 Input('log-table', 'cellValueChanged'),
                  State('N_events', 'children'),
-                 prevent_initial_call=True)(lambda time_update, log_update,
-                                            amp_update, current_str:
-                                            presenter.update_N_events(
-                                                time_update
-                                                or log_update
-                                                or amp_update,
-                                                current_str)
-                                            )
+                 prevent_initial_call=True)(presenter.update_N_events)
+
+        # clear events string if Amp value changes
+        callback(Output('N_events', 'children', allow_duplicate=True),
+                 Input('Amp', 'value'),
+                 State('N_events', 'children'),
+                 prevent_initial_call=True)(lambda *_: self.no_events_str)
 
     @property
     def no_events_str(self):

--- a/src/MuonDataLib/GUI/filters/view.py
+++ b/src/MuonDataLib/GUI/filters/view.py
@@ -68,10 +68,14 @@ class FilterView(ViewTemplate):
                   ],
                  prevent_initial_call=True)(presenter.show_file)
 
-        # clear events string if time filter changes between include/exclude
+        # clear events string if event data is made invalid
         callback(Output('N_events', 'children', allow_duplicate=True),
-                 Input('time-table_changed_state', 'data'),
-                 State('N_events', 'children'),
+                 [Input('time-table_changed_state', 'data'),
+                  Input('Amp', 'value'),
+                  Input('time-table_add', 'n_clicks'),
+                  Input('log-table_add', 'n_clicks'),
+                  Input('time-table', 'cellRendererData'),
+                  Input('log-table', 'cellRendererData')],
                  prevent_initial_call=True)(lambda *_: self.no_events_str)
 
         # clear events string if time filter parameters change
@@ -85,12 +89,6 @@ class FilterView(ViewTemplate):
                  Input('log-table', 'cellValueChanged'),
                  State('N_events', 'children'),
                  prevent_initial_call=True)(presenter.update_N_events)
-
-        # clear events string if Amp value changes
-        callback(Output('N_events', 'children', allow_duplicate=True),
-                 Input('Amp', 'value'),
-                 State('N_events', 'children'),
-                 prevent_initial_call=True)(lambda *_: self.no_events_str)
 
     @property
     def no_events_str(self):

--- a/test/GUI/filters/filters_presenter_test.py
+++ b/test/GUI/filters/filters_presenter_test.py
@@ -467,11 +467,17 @@ class FilterPresenterTest(TestHelper):
             _ = self.presenter.load(filters)
 
     def test_update_N_events_success(self):
-        result = self.presenter.update_N_events([{'colId': 'Start_time-table'}]
-                                                , 'old')
-        self.assertEqual(result, 'Number of events: Not Calculated')
+        for col_id in ['Start_time-table',
+                       'End_time-table',
+                       'filter_log-table',
+                       'y0_log-table',
+                       'yN_log-table',]:
+            result = self.presenter.update_N_events(
+                    [{'colId': col_id}], 'old'
+                    )
+            self.assertEqual(result, 'Number of events: Not Calculated')
 
-    def test_update_N_events_failt(self):
+    def test_update_N_events_fail(self):
         result = self.presenter.update_N_events([{'colId': 'unit test'}],
                                                 'old')
         self.assertEqual(result, 'old')

--- a/test/GUI/filters/filters_presenter_test.py
+++ b/test/GUI/filters/filters_presenter_test.py
@@ -467,11 +467,13 @@ class FilterPresenterTest(TestHelper):
             _ = self.presenter.load(filters)
 
     def test_update_N_events_success(self):
-        result = self.presenter.update_N_events(True, 'old')
+        result = self.presenter.update_N_events([{'colId': 'Start_time-table'}]
+                                                , 'old')
         self.assertEqual(result, 'Number of events: Not Calculated')
 
     def test_update_N_events_failt(self):
-        result = self.presenter.update_N_events(False, 'old')
+        result = self.presenter.update_N_events([{'colId': 'unit test'}],
+                                                'old')
         self.assertEqual(result, 'old')
 
 


### PR DESCRIPTION
This PR adds a callback that clears the number of events when the filters are changed. Fixes #84
