### PR TITLE
Better handling of number of periods in event data

### DIFF
--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -137,6 +137,7 @@ cdef class Events:
     cdef public int [:] periods
     cdef public double[:] times
     cdef readonly int N_spec
+    cdef readonly int N_periods
     cdef public int[:] start_index_list
     cdef public int[:] end_index_list
     cdef readonly dict[str, double] filter_start
@@ -175,6 +176,7 @@ cdef class Events:
         self.filter_start = {}
         self.filter_end = {}
         self.periods = periods
+        self.N_periods = np.max(self.periods) + 1 
         self.peak_prop = {'Amplitudes': amps}
         self.clear_thresholds()
 
@@ -458,6 +460,7 @@ cdef class Events:
                                            spec=IDs,
                                            N_spec=self.N_spec,
                                            periods=periods,
+                                           N_periods=self.N_periods,
                                            min_time=min_time,
                                            max_time=max_time,
                                            width=width,
@@ -467,6 +470,7 @@ cdef class Events:
                                            spec=IDs,
                                            N_spec=self.N_spec,
                                            periods=periods,
+                                           N_periods=self.N_periods,
                                            min_time=min_time,
                                            max_time=max_time,
                                            width=width,

--- a/src/MuonDataLib/cython_ext/load_events.pyx
+++ b/src/MuonDataLib/cython_ext/load_events.pyx
@@ -20,6 +20,7 @@ def _load_data(file_name):
 
         with h5py.File(file_name, 'r') as file:
             tmp = file.require_group('raw_data_1')
+
             tmp = tmp.require_group('detector_1_events')
 
             N = tmp['event_id'].len()

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -11,6 +11,7 @@ cpdef make_histogram(
         cnp.int32_t[:] spec,
         int N_spec,
         int[:] periods,
+        int N_periods,
         int[:] weight,
         double min_time=0,
         double max_time=30.,
@@ -28,6 +29,7 @@ cpdef make_histogram(
     :param spec: the spectra for the corresponding time
     :param N_spec: the number of spectra
     :param periods: a list of the periods each event belongs to
+    :param N_periods: the number of periods
     :param weight: the weight to give each event in the histogram ( 0 or 1)
     :param min_time: the first bin edge
     :param max_time: the last bin edge
@@ -44,7 +46,7 @@ cpdef make_histogram(
 
     cdef cnp.ndarray[double, ndim=1] bins = np.arange(min_time, max_time + width, width, dtype=np.double)
 
-    cdef cnp.ndarray[int, ndim=3] result = np.zeros((np.max(periods)+1, N_spec, len(bins)-1), dtype=np.int32)
+    cdef cnp.ndarray[int, ndim=3] result = np.zeros((N_periods, N_spec, len(bins)-1), dtype=np.int32)
     cdef int[:, :, :] mat = result
     for k in range(len(times)):
         det = spec[k]

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -52,9 +52,8 @@ def load_events(file_name, N):
     """
     try:
         return _load_events(file_name, N)
-    except Exception:
-        msg = f"The file {file_name} cannot be read"
-        raise RuntimeError(msg)
+    except Exception as err:
+        raise RuntimeError(f"The file {file_name} cannot be read") from err
 
 
 def _load_events(file_name, N):
@@ -68,7 +67,6 @@ def _load_events(file_name, N):
         raw_args, start_time = read_raw_data_from_events(file)
         tmp = file.require_group('raw_data_1')
         p_group = tmp.require_group('periods')
-        p_type = p_group['type'][:]
 
         # store data in objects
         _, events = load_data(file_name, N)
@@ -94,9 +92,9 @@ def _load_events(file_name, N):
                     'affiliation: test')
 
         periods = EventsPeriods(cache,
-                                1,
+                                p_group['number'][()],
                                 'label test',
-                                p_type,
+                                p_group['type'][:],
                                 [0])
 
         detector1 = Det1(cache,

--- a/src/MuonDataLib/data/loader/load_events.py
+++ b/src/MuonDataLib/data/loader/load_events.py
@@ -92,7 +92,7 @@ def _load_events(file_name, N):
                     'affiliation: test')
 
         periods = EventsPeriods(cache,
-                                p_group['number'][()],
+                                events.N_periods,
                                 'label test',
                                 p_group['type'][:],
                                 [0])

--- a/src/MuonDataLib/data/muon_data.py
+++ b/src/MuonDataLib/data/muon_data.py
@@ -40,7 +40,11 @@ class MuonData(object):
         """
         file = h5py.File(file_name, 'w')
         for key in self._dict.keys():
-            self._dict[key].save_nxs2(file)
+            import traceback
+            try:
+                self._dict[key].save_nxs2(file)
+            except Exception:
+                print(traceback.format_exc())
         file.close()
         return
 

--- a/src/MuonDataLib/data/periods.py
+++ b/src/MuonDataLib/data/periods.py
@@ -4,7 +4,7 @@ import numpy as np
 
 class _Periods(HDF5):
     """
-    A base class to store the period informtaion for muon data
+    A base class to store the period information for muon data
     """
     def __init__(self, number, labels, p_type,
                  output):
@@ -47,7 +47,7 @@ class _Periods(HDF5):
 
 class Periods(_Periods):
     """
-    A class to store the period informtaion for muon data
+    A class to store the period information for muon data
     """
     def __init__(self, number, labels, p_type, requested,
                  raw, output, counts, sequences):
@@ -83,7 +83,7 @@ class Periods(_Periods):
 
 class EventsPeriods(_Periods):
     """
-    A class to store the period informtaion for muon data
+    A class to store the period information for muon data
     """
     def __init__(self, cache, _number, _labels, p_type,
                  _output):

--- a/src/MuonDataLib/data/periods.py
+++ b/src/MuonDataLib/data/periods.py
@@ -85,7 +85,7 @@ class EventsPeriods(_Periods):
     """
     A class to store the period information for muon data
     """
-    def __init__(self, cache, _number, _labels, p_type,
+    def __init__(self, cache, number, _labels, p_type,
                  _output):
         """
         A class to store the period data needed for a muon nexus v2 file
@@ -97,15 +97,11 @@ class EventsPeriods(_Periods):
         :param p_type: an int array representing the type of period
         :param output: an int array of the outputs
         """
-        N = len(p_type)
+        # label is a semicolon-delimited string of period names
+        label = ";".join(f'period {k + 1}' for k in range(0, number))
+        output = np.zeros(number, dtype=np.int32)
 
-        label = ''
-        for k in range(N):
-            label += f'period {k + 1};'
-        label = label[:-1]
-        output = np.zeros(N, dtype=np.int32)
-
-        super().__init__(N, label, p_type, output)
+        super().__init__(number, label, p_type, output)
         self._cache = cache
 
     def save_nxs2(self, file):

--- a/src/MuonDataLib/numba/stats.py
+++ b/src/MuonDataLib/numba/stats.py
@@ -33,12 +33,13 @@ def get_bin_edges(a_min, a_max, width):
 
 
 @numba.jit((float64[:], int32[:], int64, int32[:],
-            int32[:], float64, float64, float64,
+            int32, int32[:], float64, float64, float64,
             float64, int64), fastmath=True, parallel=True)
 def para_histogram(times,
                    spec,
                    N_spec,
                    periods,
+                   N_periods,
                    weight,
                    min_time=0,
                    max_time=30.,
@@ -53,6 +54,7 @@ def para_histogram(times,
     :param spec: the spectra for the corresponding time
     :param N_spec: the number of spectra
     :param periods: a list of the periods each event belongs to
+    :param N_periods: the number of periods
     :param weight: the weight to give each event in the histogram ( 0 or 1)
     :param min_time: the first bin edge
     :param max_time: the last bin edge
@@ -76,7 +78,7 @@ def para_histogram(times,
 
     N = 0
     result = np.zeros((N_threads,
-                       np.max(periods)+1,
+                       N_periods,
                        N_spec,
                        len(bins)-1), dtype=np.int32)
 

--- a/test/cython_ext/stats_test.py
+++ b/test/cython_ext/stats_test.py
@@ -188,6 +188,23 @@ class StatsTest(TestHelper):
         self.assertArrays(result[1][0], [0, 1, 0, 0, 1])
         self.assertArrays(result[1][1], [0, 0, 0, 2, 0])
 
+    def test_make_histogram_multiperiod_empty_period(self):
+        """
+        Test that the histogram has the correct period dimensions
+        even if one period is empty.
+        Regression test for https://github.com/ISISMuon/MuonDataLib/issues/81
+        """
+        times = np.asarray([1, 2, 3, 4, 1, 2, 3, 1, 2], dtype=np.double)
+        IDs = np.asarray([0, 1, 1, 0, 0, 1, 1, 0, 0], dtype=np.int32)
+        periods = np.asarray([0, 0, 0, 0, 0, 0, 0, 0, 0], dtype=np.int32)
+        weights = np.ones(len(IDs), dtype=np.int32)
+
+        result, bins, N = make_histogram(times, IDs, 2,
+                                         periods, 2, weights,
+                                         0, 5, 1, conversion=1.)
+        self.assertEqual(N, 9)
+        self.assertArrays(bins, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(len(result), 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/cython_ext/stats_test.py
+++ b/test/cython_ext/stats_test.py
@@ -12,7 +12,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.ones(len(IDs), dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          0, 5, 1,
                                          conversion=1.)
         self.assertArrays(bins, [0, 1, 2, 3, 4, 5])
@@ -27,7 +28,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.asarray([1, 0, 0, 1, 1, 1, 1, 0, 0], dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          0, 5, 1,
                                          conversion=1.)
         self.assertArrays(bins, [0, 1, 2, 3, 4, 5])
@@ -42,7 +44,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.ones(len(IDs), dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          1, 5, 1,
                                          conversion=1.)
         self.assertArrays(bins, [1, 2, 3, 4, 5])
@@ -58,7 +61,7 @@ class StatsTest(TestHelper):
         weights = np.ones(len(IDs), dtype=np.int32)
 
         result, bins, N = make_histogram(times, IDs, 1, periods,
-                                         weights, -1, 5, 1,
+                                         1, weights, -1, 5, 1,
                                          conversion=1.)
         self.assertArrays(bins, [-1, 0, 1, 2, 3, 4, 5])
         self.assertEqual(len(result), 1)
@@ -72,7 +75,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.ones(len(IDs), dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          0, 5, 1,
                                          conversion=1.)
         self.assertArrays(bins, [0, 1, 2, 3, 4, 5])
@@ -88,7 +92,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.ones(len(IDs), dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          0, 5, 1,
                                          conversion=1.)
         self.assertEqual(N, 4)
@@ -103,7 +108,8 @@ class StatsTest(TestHelper):
         periods = np.zeros(len(IDs), dtype=np.int32)
         weights = np.ones(len(IDs), dtype=np.int32)
 
-        result, bins, N = make_histogram(times, IDs, 1, periods, weights,
+        result, bins, N = make_histogram(times, IDs, 1, periods,
+                                         1, weights,
                                          -5, -2, 1, conversion=1.)
         self.assertArrays(bins, [-5, -4, -3, -2])
         self.assertEqual(N, 4)
@@ -118,7 +124,7 @@ class StatsTest(TestHelper):
         weights = np.ones(len(IDs), dtype=np.int32)
 
         result, bins, N = make_histogram(times, IDs,
-                                         1, periods,
+                                         1, periods, 1,
                                          weights,
                                          0, 0.4, width=.10,
                                          conversion=1.)
@@ -136,7 +142,7 @@ class StatsTest(TestHelper):
         weights = np.ones(len(IDs), dtype=np.int32)
 
         result, bins, N = make_histogram(times, IDs,
-                                         1, periods,
+                                         1, periods, 1,
                                          weights,
                                          0, 0.5, .1, conversion=0.1)
         self.assertArrays(bins, [0, .1, .2, .3, .4, .5])
@@ -153,7 +159,7 @@ class StatsTest(TestHelper):
         weights = np.ones(len(IDs), dtype=np.int32)
 
         result, bins, N = make_histogram(times, IDs, 4,
-                                         periods, weights,
+                                         periods, 1, weights,
                                          0, 5, 1, conversion=1.)
         self.assertEqual(N, 9)
         self.assertArrays(bins, [0, 1, 2, 3, 4, 5])
@@ -171,7 +177,7 @@ class StatsTest(TestHelper):
         weights = np.ones(len(IDs), dtype=np.int32)
 
         result, bins, N = make_histogram(times, IDs, 2,
-                                         periods, weights,
+                                         periods, 2, weights,
                                          0, 5, 1, conversion=1.)
         self.assertEqual(N, 9)
         self.assertArrays(bins, [0, 1, 2, 3, 4, 5])

--- a/test/numba/numba_stats_test.py
+++ b/test/numba/numba_stats_test.py
@@ -50,7 +50,7 @@ class NumbaStatsTest(unittest.TestCase):
         10.0 -> ignore (>3)
         """
         result, bins, N = para_histogram(
-            times, spec, 1, periods, weight,
+            times, spec, 1, periods, 1, weight,
             min_time=0.0, max_time=3.0, width=1.0,
             conversion=1.0, N_threads=2
         )
@@ -68,7 +68,7 @@ class NumbaStatsTest(unittest.TestCase):
         weight = np.array([1, 0, 1], dtype=np.int32)
 
         result, bins, N = para_histogram(
-            times, spec, 1, periods, weight,
+            times, spec, 1, periods, 1, weight,
             min_time=0.0, max_time=2.0, width=1.0,
             conversion=1.0, N_threads=2
         )
@@ -84,7 +84,7 @@ class NumbaStatsTest(unittest.TestCase):
         weight = np.array([1, 1], dtype=np.int32)
 
         result, bins, N = para_histogram(
-            times, spec, 1, periods, weight,
+            times, spec, 1, periods, 1, weight,
             min_time=0.0, max_time=2.0, width=1.0,
             conversion=1e-3, N_threads=2
         )
@@ -109,7 +109,7 @@ class NumbaStatsTest(unittest.TestCase):
         weight = np.array([1, 1, 1, 1, 1, 1], dtype=np.int32)
 
         result, bins, N = para_histogram(
-            times, spec, 3, periods, weight,
+            times, spec, 3, periods, 2, weight,
             min_time=0.0, max_time=2.0, width=1.0,
             conversion=1.0, N_threads=2
         )


### PR DESCRIPTION
Fixes #81. This PR fixes the number of periods in the histogram. 

Previously, it used the largest period number in the _filtered_ data, which means if all data from the last period is filtered out then the histogram was a period too small. It now uses the largest period number in _all_ the data (as in some nexus files the `number` parameter which is meant to give the number of periods is not given or is wrong).

To test: #81 has an example to reproduce the bug. For me (working on IDAaaS) I successfully saved the histograms and loaded them on WiMDA with these changes.