### PR TITLE
Speed up filtering

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
            os: [windows-latest, ubuntu-latest, macOS-latest]
-           python_version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+           python_version: ['3.10', '3.11', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -71,7 +71,7 @@ jobs:
         if: ${{ matrix.os  == 'ubuntu-latest' }}
         with:
           qt: true
- 
+
       - name: run tests
         timeout-minutes: 10
         shell: bash -l {0}

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -4,8 +4,7 @@ from MuonDataLib.cython_ext.filter import (
                                            get_indices,
                                            rm_overlaps,
                                            good_periods,
-                                           good_values_ints,
-                                           good_values_double)
+                                           get_good_values)
 from MuonDataLib.numba.stats import para_histogram
 import numpy as np
 cimport numpy as cnp
@@ -400,28 +399,19 @@ cdef class Events:
         cdef int[:] f_i_start, f_i_end
         cdef int[:] rm_frames = np.zeros(np.max(self.periods) + 1, dtype=np.int32)
         cdef cnp.ndarray[double, ndim=1] times, amps
+        cdef int mask_size = len(self.peak_prop['Amplitudes'])
+        cdef cnp.ndarray[int] mask = np.empty(mask_size, dtype=np.int32)
 
         if len(self.filter_start.keys())>0:
             f_i_start, f_i_end, rm_frames = self._get_exclude_windows()
-
-            IDs = good_values_ints(f_i_start, f_i_end, self.start_index_list, self.IDs)
-            times = good_values_double(f_i_start, f_i_end, self.start_index_list, self.times)
-            amps = good_values_double(f_i_start, f_i_end, self.start_index_list,
-                                      self.peak_prop['Amplitudes'])
-
-            if len(times) == 0:
-                raise ValueError("The current filter selection results in zero data "
-                                 "for the histograms. Aborting histogram generation.")
+            mask = get_good_values(f_i_start, f_i_end, self.start_index_list, mask_size)
         else:
             # no filters
-            IDs = np.asarray(self.IDs)
-            times = np.asarray(self.times)
-            amps = np.asarray(self.peak_prop['Amplitudes'])
             f_i_start = np.asarray([], dtype=np.int32)
             f_i_end = np.asarray([], dtype=np.int32)
         # get the periods for each event
         periods = good_periods(f_i_start, f_i_end, self.start_index_list, self.periods, len(self.times))
-        return f_i_start, f_i_end, rm_frames, IDs, times, periods, amps
+        return f_i_start, f_i_end, rm_frames, mask 
 
     def histogram(self,
                   double min_time=0.,
@@ -441,17 +431,23 @@ cdef class Events:
         :param N_threads: the number of threads to run on
         :returns: a matrix of histograms, bin edges
         """
-        cdef cnp.ndarray[int, ndim=1] IDs, periods
+        cdef cnp.ndarray[int, ndim=1] periods
+        cdef int[:] IDs
+        cdef double[:] times, amps
         cdef int[:] f_i_start, f_i_end
         cdef int[:] rm_frames
-        cdef cnp.ndarray[double, ndim=1] times
 
         cdef double[:] frame_times = ns_to_s*np.asarray(self.get_start_times())
 
-        f_i_start, f_i_end, rm_frames, IDs, times, periods, amps = self._get_filtered_data(frame_times)
+        f_i_start, f_i_end, rm_frames, mask = self._get_filtered_data(frame_times)
+        IDs = self.IDs
+        times = self.times
+        amps = self.peak_prop['Amplitudes']
+        periods = good_periods(f_i_start, f_i_end, self.start_index_list, self.periods, len(self.times))
 
         cdef cnp.ndarray[int, ndim=1] weight = np.array(np.where(amps > np.double(self.threshold['Amplitudes']),
                                                                  1., 0.), dtype=np.int32)
+        weight = weight * mask
 
         cdef double width = (max_time - min_time) / num_bins
 
@@ -466,15 +462,15 @@ cdef class Events:
                                            width=width,
                                            weight=weight)
         elif N_threads > 1:
-            hist, bins, N = para_histogram(times=times,
-                                           spec=IDs,
+            hist, bins, N = para_histogram(times=np.asarray(times, dtype=double),
+                                           spec=np.asarray(IDs, dtype=np.int32),
                                            N_spec=self.N_spec,
                                            periods=periods,
                                            N_periods=self.N_periods,
                                            min_time=min_time,
                                            max_time=max_time,
                                            width=width,
-                                           weight=weight,
+                                           weight=np.asarray(weight, dtype=np.int32),
                                            conversion=1.e-3,
                                            N_threads=N_threads)
         else:

--- a/src/MuonDataLib/cython_ext/event_data.pyx
+++ b/src/MuonDataLib/cython_ext/event_data.pyx
@@ -3,7 +3,7 @@ from MuonDataLib.cython_ext.stats import make_histogram
 from MuonDataLib.cython_ext.filter import (
                                            get_indices,
                                            rm_overlaps,
-                                           good_periods,
+                                           get_event_periods,
                                            get_good_values)
 from MuonDataLib.numba.stats import para_histogram
 import numpy as np
@@ -395,22 +395,18 @@ cdef class Events:
         the amplitudes of the kept events.
         """
 
-        cdef cnp.ndarray[int, ndim=1] IDs, periods
         cdef int[:] f_i_start, f_i_end
         cdef int[:] rm_frames = np.zeros(np.max(self.periods) + 1, dtype=np.int32)
-        cdef cnp.ndarray[double, ndim=1] times, amps
         cdef int mask_size = len(self.peak_prop['Amplitudes'])
-        cdef cnp.ndarray[int] mask = np.empty(mask_size, dtype=np.int32)
+        cdef cnp.ndarray[int] mask = np.ones(mask_size, dtype=np.int32)
 
         if len(self.filter_start.keys())>0:
             f_i_start, f_i_end, rm_frames = self._get_exclude_windows()
-            mask = get_good_values(f_i_start, f_i_end, self.start_index_list, mask_size)
+            mask = np.asarray(get_good_values(f_i_start, f_i_end, self.start_index_list, mask_size))
         else:
             # no filters
             f_i_start = np.asarray([], dtype=np.int32)
             f_i_end = np.asarray([], dtype=np.int32)
-        # get the periods for each event
-        periods = good_periods(f_i_start, f_i_end, self.start_index_list, self.periods, len(self.times))
         return f_i_start, f_i_end, rm_frames, mask 
 
     def histogram(self,
@@ -443,7 +439,7 @@ cdef class Events:
         IDs = self.IDs
         times = self.times
         amps = self.peak_prop['Amplitudes']
-        periods = good_periods(f_i_start, f_i_end, self.start_index_list, self.periods, len(self.times))
+        periods = get_event_periods(self.start_index_list, self.periods, len(self.times))
 
         cdef cnp.ndarray[int, ndim=1] weight = np.array(np.where(amps > np.double(self.threshold['Amplitudes']),
                                                                  1., 0.), dtype=np.int32)
@@ -462,7 +458,7 @@ cdef class Events:
                                            width=width,
                                            weight=weight)
         elif N_threads > 1:
-            hist, bins, N = para_histogram(times=np.asarray(times, dtype=double),
+            hist, bins, N = para_histogram(times=np.asarray(times, dtype=np.float64),
                                            spec=np.asarray(IDs, dtype=np.int32),
                                            N_spec=self.N_spec,
                                            periods=periods,

--- a/src/MuonDataLib/cython_ext/filter.pyx
+++ b/src/MuonDataLib/cython_ext/filter.pyx
@@ -30,8 +30,8 @@ cpdef get_indices(double[:] times, double[:] f_start, double[:] f_end,
     """
     cdef int N = len(f_start)
     cdef int M = len(times)
-    cdef cnp.ndarray[int, ndim=1] _j_start = np.zeros(N, dtype=np.int32)
-    cdef cnp.ndarray[int, ndim=1] _j_end = np.zeros(N, dtype=np.int32)
+    cdef cnp.ndarray[int, ndim=1] _j_start = np.empty(N, dtype=np.int32)
+    cdef cnp.ndarray[int, ndim=1] _j_end = np.empty(N, dtype=np.int32)
     cdef int j
     cdef int[:] j_start = _j_start
     cdef int[:] j_end = _j_end
@@ -91,8 +91,8 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
     """
     # there will be at most the same number of filters
     cdef int N = len(j_start)
-    cdef cnp.ndarray[int, ndim=1] _final_start = np.zeros(N, dtype=np.int32)
-    cdef cnp.ndarray[int, ndim=1] _final_end = np.zeros(N, dtype=np.int32)
+    cdef cnp.ndarray[int, ndim=1] _final_start = np.empty(N, dtype=np.int32)
+    cdef cnp.ndarray[int, ndim=1] _final_end = np.empty(N, dtype=np.int32)
     cdef int[:] final_start = _final_start
     cdef int[:] final_end = _final_end
     cdef int start = j_start[0]
@@ -124,7 +124,7 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
     N = N+1
 
     # get removed frames
-    cdef int[:] rm_frames = np.zeros(np.max(periods) + 1, dtype=np.int32)
+    cdef int[:] rm_frames = np.empty(np.max(periods) + 1, dtype=np.int32)
     for k in prange(N, nogil=True):
         start = final_start[k]
         for j in range(final_end[k] - start + 1):
@@ -150,7 +150,7 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
     cdef Py_ssize_t M, j, k, end, dm, filter_start
     cdef Py_ssize_t len_filters = len(f_start)
     cdef Py_ssize_t N_frames = len(start_index)
-    cdef cnp.ndarray[int] _good_periods = np.zeros(N_events,
+    cdef cnp.ndarray[int] _good_periods = np.empty(N_events,
                                                    dtype=np.int32)
     cdef int[:] good_periods = _good_periods
     start = 0
@@ -165,8 +165,7 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
         if k < filter_start:
             end = start_index[k+1]
             dm = end - start
-            for dm_i in range(dm):
-                good_periods[M + dm_i] = periods[k]
+            good_periods[M:M + dm] = periods[k]
             M += dm
             start = end
         elif k == f_end[j]:
@@ -178,79 +177,43 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
                 filter_start = f_start[j]
 
     dm = N_events - start_index[N_frames-1]
-    for dm_i in range(dm):
-        good_periods[M + dm_i] = periods[len(periods)-1]
+    good_periods[M:M + dm] = periods[len(periods)-1]
     M += dm
     return _good_periods[:M]
 
-
-@cython.boundscheck(False)  # Deactivate bounds checking
-@cython.wraparound(False)   # Deactivate negative indexing.
-cpdef good_values_ints(int[:] f_start, int[:] f_end, int[:] start_index, int[:] int_array):
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef get_good_values(int[:] f_start, int[:] f_end, int[:] start_index, int array_len):
     """
-    This removes the values from the array corresponding to the filtered frames.
+    Get a boolean mask corresponding to the filtered frames.
     :param f_start: the start indices for the filters (no overlaps)
     :param f_end: the end indices for the filters (no overlaps)
-    :param start_index: a list that gives the first index in int_array for that frame
-    :param int_array: the array to remove data from
-    :return: the int_array with the data in the filtered frames removed
+    :param start_index: a list that gives the first index in the for that frame
+    :param array_len: the length of the array
+    :return: a boolean mask such that array[mask] gives the filtered frames.
     """
+    cdef int start = 0
+    cdef int k, last, chunk
+    cdef cnp.ndarray[int] _mask = np.zeros(array_len, dtype=np.int32)
+    cdef int[:] mask = _mask
+    cdef int N = 0
+    cdef int M = len(f_start)
+    cdef int len_start_index = len(start_index)  # cache length
 
-    cdef Py_ssize_t start = 0
-    cdef cnp.ndarray[int] _good_ints = np.zeros(len(int_array), dtype=np.int32)
-    cdef int[:] good_ints = _good_ints
-    cdef Py_ssize_t k, last
-    cdef Py_ssize_t v, N, i
-    cdef Py_ssize_t M = len(f_start)
-    N = 0
-
-    for k in range(M):
+    for k in prange(M, nogil=True):
         last = start_index[f_start[k]]
-        for v in range(start, last):
-            good_ints[N] = int_array[v]
-            N += 1
-        i = f_end[k] + 1
-        if i < len(start_index):
+        mask[start:last] = 1
+
+        if f_end[k] + 1 < len_start_index:
             start = start_index[f_end[k] + 1]
 
     # check if filter covers last frame
-    if f_end[M-1] + 1 >= len(start_index):
-        return _good_ints[:N]
-    last = len(int_array)
-    for v in range(start, last):
-        good_ints[N] = int_array[v]
-        N += 1
-    return _good_ints[:N]
+    if f_end[M-1] + 1 >= len_start_index:
+        return mask
 
-@cython.boundscheck(False)  # Deactivate bounds checking
-@cython.wraparound(False)   # Deactivate negative indexing.
-cpdef good_values_double(int[:] f_start, int[:] f_end, int[:] start_index, double[:] double_array):
-    cdef Py_ssize_t start = 0
-    cdef cnp.ndarray[double] _good_doubles = np.zeros(len(double_array), dtype=np.double)
-    cdef double[:] good_doubles = _good_doubles
-    cdef Py_ssize_t k, last
-    cdef Py_ssize_t v, N, i
-    cdef Py_ssize_t M = len(f_start)
-    N = 0
-
-    for k in range(M):
-        last = start_index[f_start[k]]
-        for v in range(start, last):
-            good_doubles[N] = double_array[v]
-            N += 1
-        i = f_end[k] +1
-        if i < len(start_index):
-            start = start_index[f_end[k] + 1]
-
-    # check if filter covers last frame
-    if f_end[M-1] + 1 >= len(start_index):
-        return _good_doubles[:N]
-    last = len(double_array)
-    for v in range(start, last):
-        good_doubles[N] = double_array[v]
-        N += 1
-    return _good_doubles[:N]
-
+    last = array_len 
+    mask[start:last] = 1 
+    return _mask
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
@@ -262,8 +225,8 @@ cpdef apply_filter(x, y, times):
     :param times: a list of the [start, end] times
     within which the data will be removed
     """
-    cdef cnp.ndarray[double] _fx = np.zeros(len(x), dtype=np.double)
-    cdef cnp.ndarray[double] _fy = np.zeros(len(y), dtype=np.double)
+    cdef cnp.ndarray[double] _fx = np.empty(len(x), dtype=np.double)
+    cdef cnp.ndarray[double] _fy = np.empty(len(y), dtype=np.double)
     cdef double[:] fx = _fx
     cdef double[:] fy = _fy
     # these are defined to make the loop not require the GIL so it is parallelisable

--- a/src/MuonDataLib/cython_ext/filter.pyx
+++ b/src/MuonDataLib/cython_ext/filter.pyx
@@ -95,14 +95,14 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
     cdef cnp.ndarray[int, ndim=1] _final_end = np.zeros(N, dtype=np.int32)
     cdef int[:] final_start = _final_start
     cdef int[:] final_end = _final_end
-    cdef int one = 1
     cdef int start = j_start[0]
     cdef int end = j_end[0]
     cdef int k, next_start, next_end, j
+    cdef int N_filters = len(j_start)  # to make the actual code pure C
 
     # due to overlaps the number of filters might be smaller
     N = 0
-    for k in range(1, len(j_start)):
+    for k in prange(1, N_filters, nogil=True):
         next_start = j_start[k]
         next_end = j_end[k]
 
@@ -110,7 +110,7 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
         if end < next_start:
             final_start[N] = start
             final_end[N] = end
-            N += 1
+            N = N + 1
             start = next_start
             end = next_end
 
@@ -125,9 +125,9 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
 
     # get removed frames
     cdef int[:] rm_frames = np.zeros(np.max(periods) + 1, dtype=np.int32)
-    for k in range(N):
-        start = _final_start[k]
-        for j in range(_final_end[k] - start + 1):
+    for k in prange(N, nogil=True):
+        start = final_start[k]
+        for j in range(final_end[k] - start + 1):
             rm_frames[periods[start + j]] += 1
 
     return _final_start[:N], _final_end[:N], rm_frames

--- a/src/MuonDataLib/cython_ext/filter.pyx
+++ b/src/MuonDataLib/cython_ext/filter.pyx
@@ -3,7 +3,6 @@ from MuonDataLib.cython_ext.utils import binary_search
 import numpy as np
 cimport numpy as cnp
 import cython
-from cython.parallel import prange
 cnp.import_array()
 
 
@@ -102,7 +101,7 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
 
     # due to overlaps the number of filters might be smaller
     N = 0
-    for k in prange(1, N_filters, nogil=True):
+    for k in range(1, N_filters):
         next_start = j_start[k]
         next_end = j_end[k]
 
@@ -185,7 +184,7 @@ cpdef get_good_values(int[:] f_start, int[:] f_end, int[:] start_index, int arra
     cdef int M = len(f_start)
     cdef int len_start_index = len(start_index)  # cache length
 
-    for k in prange(M, nogil=True):
+    for k in range(M):
         last = start_index[f_start[k]]
         mask[start:last] = 1
 
@@ -225,10 +224,9 @@ cpdef apply_filter(x, y, times):
 
     N = 0
     k = 0
-    for j in prange(num_x, nogil=True):
-        with cython.gil:
-            current_x = x[j]
-            current_y = y[j]
+    for j in range(num_x):
+        current_x = x[j]
+        current_y = y[j]
         if k == len(start_times) or current_x < start_times[k]:
             fx[N] = current_x
             fy[N] = current_y

--- a/src/MuonDataLib/cython_ext/filter.pyx
+++ b/src/MuonDataLib/cython_ext/filter.pyx
@@ -124,10 +124,10 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
     N = N+1
 
     # get removed frames
-    cdef int[:] rm_frames = np.empty(np.max(periods) + 1, dtype=np.int32)
-    for k in prange(N, nogil=True):
-        start = final_start[k]
-        for j in range(final_end[k] - start + 1):
+    cdef int[:] rm_frames = np.zeros(np.max(periods) + 1, dtype=np.int32)
+    for k in range(N):
+        start = _final_start[k]
+        for j in range(_final_end[k] - start + 1):
             rm_frames[periods[start + j]] += 1
 
     return _final_start[:N], _final_end[:N], rm_frames
@@ -135,11 +135,9 @@ cpdef rm_overlaps(int[:] j_start, int[:] j_end, int[:] periods):
 
 @cython.boundscheck(False)  # Deactivate bounds checking
 @cython.wraparound(False)   # Deactivate negative indexing.
-cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] periods, int N_events):
+cpdef get_event_periods(int[:] start_index, int[:] periods, int N_events):
     """
-    This removes the values from the array corresponding to the filtered frames.
-    :param f_start: the start indices for the filters (no overlaps)
-    :param f_end: the end indices for the filters (no overlaps)
+    Get the period corresponding to each event.
     :param start_index: a list that gives the first index in int_array for that frame
     :param periods: the array identifing the period for each frame
     :param N_events: the number of events
@@ -147,8 +145,7 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
     """
 
     cdef Py_ssize_t start = 0
-    cdef Py_ssize_t M, j, k, end, dm, filter_start
-    cdef Py_ssize_t len_filters = len(f_start)
+    cdef Py_ssize_t M, j, k, end, dm
     cdef Py_ssize_t N_frames = len(start_index)
     cdef cnp.ndarray[int] _good_periods = np.empty(N_events,
                                                    dtype=np.int32)
@@ -156,25 +153,13 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
     start = 0
     M = 0
     j = 0
-    if len_filters > 0:
-        filter_start = f_start[0]
-    else:
-        filter_start = N_events + 1
 
     for k in range(N_frames - 1):
-        if k < filter_start:
-            end = start_index[k+1]
-            dm = end - start
-            good_periods[M:M + dm] = periods[k]
-            M += dm
-            start = end
-        elif k == f_end[j]:
-            j += 1
-            start = start_index[k+1]
-            if j == len_filters:
-                filter_start = N_events + 1
-            else:
-                filter_start = f_start[j]
+        end = start_index[k+1]
+        dm = end - start
+        good_periods[M:M + dm] = periods[k]
+        M += dm
+        start = end
 
     dm = N_events - start_index[N_frames-1]
     good_periods[M:M + dm] = periods[len(periods)-1]

--- a/src/MuonDataLib/cython_ext/filter.pyx
+++ b/src/MuonDataLib/cython_ext/filter.pyx
@@ -3,6 +3,7 @@ from MuonDataLib.cython_ext.utils import binary_search
 import numpy as np
 cimport numpy as cnp
 import cython
+from cython.parallel import prange
 cnp.import_array()
 
 
@@ -164,7 +165,8 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
         if k < filter_start:
             end = start_index[k+1]
             dm = end - start
-            good_periods[M:M+dm] = periods[k]
+            for dm_i in range(dm):
+                good_periods[M + dm_i] = periods[k]
             M += dm
             start = end
         elif k == f_end[j]:
@@ -176,7 +178,8 @@ cpdef good_periods(int[:] f_start, int[:] f_end, int[:] start_index, int[:] peri
                 filter_start = f_start[j]
 
     dm = N_events - start_index[N_frames-1]
-    good_periods[M:M + dm] = periods[len(periods)-1]
+    for dm_i in range(dm):
+        good_periods[M + dm_i] = periods[len(periods)-1]
     M += dm
     return _good_periods[:M]
 
@@ -259,25 +262,35 @@ cpdef apply_filter(x, y, times):
     :param times: a list of the [start, end] times
     within which the data will be removed
     """
-    fx = np.zeros(len(x))
-    fy = np.zeros(len(y))
+    cdef cnp.ndarray[double] _fx = np.zeros(len(x), dtype=np.double)
+    cdef cnp.ndarray[double] _fy = np.zeros(len(y), dtype=np.double)
+    cdef double[:] fx = _fx
+    cdef double[:] fy = _fy
+    # these are defined to make the loop not require the GIL so it is parallelisable
+    cdef double current_x
+    cdef double current_y
+    cdef int num_x = len(x)
     # need to make sure the times are in the correct order
     cdef double[:] start_times= np.sort(np.asarray([ times[k][0] for k in range(len(times))], dtype=np.double), kind='quicksort')
     cdef double[:] end_times= np.sort(np.asarray([ times[k][1] for k in range(len(times))], dtype=np.double), kind='quicksort')
+    cdef Py_ssize_t N, k, j
 
     N = 0
     k = 0
-    for j in range(len(x)):
-        if k == len(start_times) or x[j] < start_times[k]:
-            fx[N] = x[j]
-            fy[N] = y[j]
-            N += 1
+    for j in prange(num_x, nogil=True):
+        with cython.gil:
+            current_x = x[j]
+            current_y = y[j]
+        if k == len(start_times) or current_x < start_times[k]:
+            fx[N] = current_x
+            fy[N] = current_y
+            N = N + 1
 
-        elif x[j] >= end_times[k]:
-            k += 1
-            if k < len(start_times) and x[j] < start_times[k]:
-                fx[N] = x[j]
-                fy[N] = y[j]
-                N += 1
+        elif current_x >= end_times[k]:
+            k = k + 1
+            if k < len(start_times) and current_x < start_times[k]:
+                fx[N] = current_x
+                fy[N] = current_y
+                N = N + 1
 
-    return fx[:N], fy[:N]
+    return _fx[:N], _fy[:N]

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -51,10 +51,10 @@ cpdef make_histogram(
     for k in range(len(times)):
         det = spec[k]
         time = times[k] * conversion
-        if time <= max_time and time >= min_time:
+        w_k = 1*weight[k]
+        if time <= max_time and time >= min_time and w_k != 0:
             p = periods[k]
             j_bin = int((time - min_time) // width)
-            w_k = 1*weight[k]
             mat[p, det, j_bin] += w_k
             N += w_k
     return result, bins, N

--- a/src/MuonDataLib/cython_ext/stats.pyx
+++ b/src/MuonDataLib/cython_ext/stats.pyx
@@ -52,7 +52,7 @@ cpdef make_histogram(
         det = spec[k]
         time = times[k] * conversion
         w_k = 1*weight[k]
-        if time <= max_time and time >= min_time and w_k != 0:
+        if w_k != 0 and time <= max_time and time >= min_time:
             p = periods[k]
             j_bin = int((time - min_time) // width)
             mat[p, det, j_bin] += w_k

--- a/src/MuonDataLib/numba/stats.py
+++ b/src/MuonDataLib/numba/stats.py
@@ -92,11 +92,11 @@ def para_histogram(times,
             stop = len(times)
         for k in range(start, stop):
             time = times[k]*conversion
-            if time <= max_time and time >= min_time:
+            w = weight[k]
+            if time <= max_time and time >= min_time and w != 0:
                 j_bin = int((time - min_time) // width)
                 p = periods[k]
                 det = spec[k]
-                w = weight[k]
                 result[thread, p, det, j_bin] += w
                 N += w
 

--- a/src/MuonDataLib/numba/stats.py
+++ b/src/MuonDataLib/numba/stats.py
@@ -93,7 +93,7 @@ def para_histogram(times,
         for k in range(start, stop):
             time = times[k]*conversion
             w = weight[k]
-            if time <= max_time and time >= min_time and w != 0:
+            if w != 0 and time <= max_time and time >= min_time:
                 j_bin = int((time - min_time) // width)
                 p = periods[k]
                 det = spec[k]

--- a/test/cython_ext/events_test.py
+++ b/test/cython_ext/events_test.py
@@ -224,35 +224,22 @@ class EventsTest(TestHelper):
         self._events.add_filter('test', 1.2, 1.7)
 
         results = self._events._get_filtered_data(1.e-9*self._frame_time)
-        f_start, f_end, rm, IDs, times, periods, amps = results
+        f_start, f_end, rm, mask = results
         self.assertArrays(np.asarray(f_start), [0])
         self.assertArrays(np.asarray(f_end), [0])
 
         self.assertArrays(rm, [1])
-        self.assertArrays(np.asarray(amps), [1.2, 1.3, 1.4, 1.5])
-        self.assertArrays(np.asarray(IDs), [0, 1, 0, 1])
-        self.assertArrays(np.asarray(times), [3000., 4000.,
-                                              5000., 6000.])
+        self.assertArrays(np.asarray(mask), np.array([0, 0, 1, 1, 1, 1]))
 
     def test_get_filtered_data_no_filter(self):
 
         results = self._events._get_filtered_data(1.e-9*self._frame_time)
-        f_start, f_end, rm, IDs, times, periods, amps = results
+        f_start, f_end, rm, mask = results
         self.assertArrays(np.asarray(f_start), [])
         self.assertArrays(np.asarray(f_end), [])
 
         self.assertArrays(rm, [0])
-        self.assertArrays(np.asarray(amps), [1, 1.1, 1.2, 1.3, 1.4, 1.5])
-        self.assertArrays(np.asarray(IDs), [0, 1, 0, 1, 0, 1])
-        self.assertArrays(np.asarray(times), [1000., 2000.,
-                                              3000., 4000.,
-                                              5000., 6000.])
-
-    def test_get_filtered_data_no_data(self):
-        self._events.add_filter('test', 0, 1e9)
-
-        with self.assertRaises(ValueError):
-            _ = self._events._get_filtered_data(1.e-9*self._frame_time)
+        self.assertArrays(np.asarray(mask), np.ones(6))
 
     def test_start_and_end_times_filter_in_middle(self):
         frame_times = np.arange(1, 20, dtype=np.double)

--- a/test/cython_ext/filter_test.py
+++ b/test/cython_ext/filter_test.py
@@ -3,10 +3,9 @@ import numpy as np
 
 from MuonDataLib.test_helpers.unit_test import TestHelper
 from MuonDataLib.cython_ext.filter import (rm_overlaps,
-                                           good_periods,
+                                           get_event_periods,
                                            get_indices,
-                                           good_values_ints,
-                                           good_values_double,
+                                           get_good_values,
                                            apply_filter)
 
 
@@ -77,30 +76,28 @@ class FilterTest(TestHelper):
         self.assertArrays(j_start, [1, 5])
         self.assertArrays(j_end, [2, 5])
 
-    def test_good_values_ints(self):
+    def test_get_good_values(self):
         f_start = np.asarray([0, 4], dtype=np.int32)
         f_end = np.asarray([1, 4], dtype=np.int32)
         start_index = np.asarray([0, 10, 20, 30, 40], dtype=np.int32)
-        int_array = np.arange(0, 45, dtype=np.int32)
 
-        result = good_values_ints(f_start,
-                                  f_end,
-                                  start_index,
-                                  int_array)
-        self.assertEqual(len(result), 20)
-        self.assertArrays(result, np.arange(20, 40))
-
-    def test_good_values_double(self):
-        f_start = np.asarray([0, 4], dtype=np.int32)
-        f_end = np.asarray([1, 4], dtype=np.int32)
-        start_index = np.asarray([0, 10, 20, 30, 40], dtype=np.int32)
-        double_array = np.arange(0, 0.45, step=0.01, dtype=np.double)
-        result = good_values_double(f_start,
-                                    f_end,
-                                    start_index,
-                                    double_array)
-        self.assertEqual(len(result), 20)
-        self.assertArrays(result, np.arange(0.2, 0.4, step=0.01))
+        result = get_good_values(f_start,
+                                 f_end,
+                                 start_index,
+                                 45)
+        # the expected result corresponds to:
+        # array = np.arange(0, 45, dtype=np.int32)
+        # (array >= 20) & (array < 40)
+        self.assertArrays(result, np.array([False, False, False, False, False,
+                                            False, False, False, False, False,
+                                            False, False, False, False, False,
+                                            False, False, False, False, False,
+                                            True, True, True, True, True,
+                                            True, True, True, True, True,
+                                            True, True, True, True, True,
+                                            True, True, True, True, True,
+                                            False, False, False, False, False])
+                          )
 
     def test_apply_filter_unordered(self):
         x = np.arange(0, 10, dtype=np.double)
@@ -128,54 +125,13 @@ class FilterTest(TestHelper):
         self.assertArrays(fx, np.asarray([0, 4, 5, 9], dtype=np.double))
         self.assertArrays(fy, np.asarray([1, 9, 11, 19], dtype=np.double))
 
-    def test_good_periods(self):
-        f_start = np.asarray([0, 4], dtype=np.int32)
-        f_end = np.asarray([1, 4], dtype=np.int32)
-        start_index = np.asarray([0, 10, 20, 30, 40], dtype=np.int32)
-        double_array = np.arange(0, 0.45, step=0.01, dtype=np.double)
-        periods = np.asarray([0, 1, 1, 0, 1], dtype=np.int32)
-        result = good_periods(f_start,
-                              f_end,
-                              start_index,
-                              periods,
-                              len(double_array))
-        self.assertEqual(len(result), 25)
-        self.assertArrays(result, np.asarray([1, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              1, 0, 0,
-                                              0, 0, 0,
-                                              0, 0, 0,
-                                              0, 0, 1,
-                                              1, 1, 1, 1]))
+    def test_get_event_periods(self):
+        frame_periods = np.array([1, 2, 1], dtype=np.int32)
+        start_index = np.array([1, 4, 6], dtype=np.int32)
+        N_events = 8
 
-    def test_good_periods_middle(self):
-        f_start = np.asarray([4, 7], dtype=np.int32)
-        f_end = np.asarray([5, 7], dtype=np.int32)
-        start_index = np.asarray([0, 10, 20, 30, 40], dtype=np.int32)
-        double_array = np.arange(0, 0.45, step=0.01, dtype=np.double)
-        periods = np.asarray([0, 1, 1, 0, 1], dtype=np.int32)
-        result = good_periods(f_start,
-                              f_end,
-                              start_index,
-                              periods,
-                              len(double_array))
-        self.assertEqual(len(result), 45)
-        self.assertArrays(result, np.asarray([0, 0, 0,
-                                              0, 0, 0,
-                                              0, 0, 0,
-                                              0, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              1, 1, 1,
-                                              0, 0, 0,
-                                              0, 0, 0,
-                                              0, 0, 0,
-                                              0, 1, 1,
-                                              1, 1, 1]))
+        event_periods = get_event_periods(start_index, frame_periods, N_events)
+        self.assertArrays(event_periods, np.array([1, 1, 1, 1, 2, 2, 1, 1]))
 
 
 if __name__ == '__main__':

--- a/test/cython_ext/multiperiod_events_test.py
+++ b/test/cython_ext/multiperiod_events_test.py
@@ -146,44 +146,6 @@ class MultiperiodEventsTest(TestHelper):
         self.assertArrays(cache.get_good_frames, [99, 99])
         self.assertEqual(cache.get_N_events, 4)
 
-    def test_get_filtered_data(self):
-        self._events.add_filter('test', 1.2, 1.7)
-
-        results = self._events._get_filtered_data(1.e-9*self._frame_time)
-        f_start, f_end, rm, IDs, times, periods, amps = results
-        self.assertArrays(np.asarray(f_start), [0])
-        self.assertArrays(np.asarray(f_end), [0])
-
-        self.assertArrays(rm, [1, 0])
-        self.assertArrays(np.asarray(amps), [1.2, 1.3, 1.4, 1.5, 1.6, 1.7])
-        self.assertArrays(np.asarray(IDs), [0, 1, 0, 1, 0, 1])
-        self.assertArrays(np.asarray(times), [3000., 4000.,
-                                              5000., 6000.,
-                                              7000., 8000.])
-        self.assertArrays(np.asarray(periods), [1, 1,
-                                                0, 0,
-                                                1, 1])
-
-    def test_get_filtered_data_no_filter(self):
-
-        results = self._events._get_filtered_data(1.e-9*self._frame_time)
-        f_start, f_end, rm, IDs, times, periods, amps = results
-        self.assertArrays(np.asarray(f_start), [])
-        self.assertArrays(np.asarray(f_end), [])
-
-        self.assertArrays(rm, [0, 0])
-        self.assertArrays(np.asarray(IDs), [0, 1, 0, 1, 0, 1, 0, 1])
-        self.assertArrays(np.asarray(amps), [1.0, 1.1, 1.2, 1.3,
-                                             1.4, 1.5, 1.6, 1.7])
-        self.assertArrays(np.asarray(times), [1000., 2000.,
-                                              3000., 4000.,
-                                              5000., 6000.,
-                                              7000., 8000.])
-        self.assertArrays(np.asarray(periods), [0, 0,
-                                                1, 1,
-                                                0, 0,
-                                                1, 1])
-
     def test_get_total_frames(self):
         self.assertArrays(self._events.get_total_frames, [2, 2])
 


### PR DESCRIPTION
This PR fixes #119 by changing the filtering. Instead of reducing the size of the arrays to the filtered values, the whole arrays are now passed to the histogram code and the filtered-out values are given a weight of zero instead.